### PR TITLE
feat(main loop): add commands execution

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -11,6 +11,7 @@
     #include <stdbool.h>
 
 typedef struct shell_s shell_t;
+typedef struct ast_node_s ast_node_t;
 
 typedef struct command_s {
     char **av;
@@ -31,5 +32,7 @@ struct shell_s {
 };
 
 ast_node_t *built_ast_struct(char *user_input);
+void process_command(ast_node_t *ast, shell_t *shell_info);
+char *read_command(void);
 
 #endif /* !SHELL_H_ */

--- a/include/shell.h
+++ b/include/shell.h
@@ -30,4 +30,6 @@ struct shell_s {
     int exit_code;
 };
 
+ast_node_t *built_ast_struct(char *user_input);
+
 #endif /* !SHELL_H_ */

--- a/src.list
+++ b/src.list
@@ -13,3 +13,4 @@ src/parser/parse_command.c
 src/parser/parse_sequence.c
 src/parser/parse_pipes.c
 src/parser/parse_and_or.c
+src/main_loop/handle_user_input.c

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,7 @@ static void main_loop(shell_t *shell_info)
             break;
         if (user_input[0] != '\n') {
             ast = built_ast_struct(user_input);
+            free(user_input);
         }
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,14 +1,47 @@
 /*
 ** EPITECH PROJECT, 2025
-** clonerepo [WSL: Ubuntu-24.04]
+** 42sh
 ** File description:
 ** main
 */
 
+#include "shell.h"
+#include "ast.h"
+#include "lexer.h"
+#include <unistd.h>
 #include <stdio.h>
+#include <string.h>
 
-int main(int ac, char const **av)
+static void display_prompt(void)
 {
-    printf("Hello, World!\n");
+    write(STDOUT_FILENO, "$>", strlen("$>"));
+}
+
+static void main_loop(shell_t *shell_info)
+{
+    int is_interactive = isatty(STDIN_FILENO);
+    ast_node_t *ast;
+    char *user_input;
+
+    while (1) {
+        if (is_interactive)
+            display_prompt();
+        user_input = read_command();
+        if (user_input == NULL)
+            break;
+        if (user_input[0] != '\n') {
+            ast = built_ast_struct(user_input);
+            process_command(ast, shell_info);
+        }
+    }
+}
+
+int main(int argc, char **argv, char **env)
+{
+    shell_t *shell_info = malloc(sizeof(shell_t));
+
+    (void)argc;
+    (void)argv;
+    main_loop(shell_info);
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -31,7 +31,6 @@ static void main_loop(shell_t *shell_info)
             break;
         if (user_input[0] != '\n') {
             ast = built_ast_struct(user_input);
-            process_command(ast, shell_info);
         }
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,7 @@
 
 static void display_prompt(void)
 {
-    write(STDOUT_FILENO, "$>", strlen("$>"));
+    write(STDOUT_FILENO, "$>", 2);
 }
 
 static void main_loop(shell_t *shell_info)

--- a/src/main_loop/handle_user_input.c
+++ b/src/main_loop/handle_user_input.c
@@ -32,12 +32,12 @@ ast_node_t *built_ast_struct(char *user_input)
     tokens = lexer(user_input);
     if (!tokens) {
         fprintf(stderr, "Lexer failed\n");
-        exit(1);
+        return NULL;
     }
     ast = parse_sequence(tokens, &pos);
     if (!ast) {
         fprintf(stderr, "Parser failed\n");
-        exit(1);
+        return NULL;
     }
     return ast;
 }

--- a/src/main_loop/handle_user_input.c
+++ b/src/main_loop/handle_user_input.c
@@ -11,7 +11,7 @@
 #include <unistd.h>
 #include <stdio.h>
 
-static char *read_command(void)
+char *read_command(void)
 {
     char *line = NULL;
     size_t len = 0;

--- a/src/main_loop/handle_user_input.c
+++ b/src/main_loop/handle_user_input.c
@@ -1,0 +1,43 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** handle_user_input
+*/
+
+#include "shell.h"
+#include "ast.h"
+#include "lexer.h"
+#include <unistd.h>
+#include <stdio.h>
+
+static char *read_command(void)
+{
+    char *line = NULL;
+    size_t len = 0;
+
+    if (getline(&line, &len, stdin) == -1) {
+        free(line);
+        return NULL;
+    }
+    return line;
+}
+
+ast_node_t *built_ast_struct(char *user_input)
+{
+    char **tokens;
+    ast_node_t *ast;
+    int pos = 0;
+
+    tokens = lexer(user_input);
+    if (!tokens) {
+        fprintf(stderr, "Lexer failed\n");
+        exit(1);
+    }
+    ast = parse_sequence(tokens, &pos);
+    if (!ast) {
+        fprintf(stderr, "Parser failed\n");
+        exit(1);
+    }
+    return ast;
+}

--- a/src/main_loop/process_command.c
+++ b/src/main_loop/process_command.c
@@ -10,5 +10,5 @@
 
 void process_command(ast_node_t *ast, shell_t *shell_info)
 {
-    return execute_functions[ast->type](ast, shell_info);
+    execute_functions[ast->type](ast, shell_info);
 }

--- a/src/main_loop/process_command.c
+++ b/src/main_loop/process_command.c
@@ -1,0 +1,14 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** process_command
+*/
+
+#include "ast.h"
+#include <stdio.h>
+
+void process_command(ast_node_t *ast, shell_t *shell_info)
+{
+    return execute_functions[ast->type](ast, shell_info);
+}


### PR DESCRIPTION
This pull request introduces significant changes to the `42sh` project, primarily focusing on the implementation of a main loop for handling user input and processing commands. The key changes include the addition of new functions for reading commands, building AST structures, and processing commands, as well as modifications to the main function to integrate these new functionalities.

### Main Loop Implementation:

* **Addition of `main_loop` function**: Introduced a new `main_loop` function in `src/main.c` to handle the interactive shell prompt, read user input, and build AST structures.
* **Display prompt function**: Added a `display_prompt` function to show the shell prompt to the user.

### AST and Command Processing:

* **New functions in `include/shell.h`**: Added declarations for `built_ast_struct`, `process_command`, and `read_command` functions.
* **Implementation of `read_command` and `built_ast_struct`**: Created `read_command` to read user input and `built_ast_struct` to build AST structures from the input in `src/main_loop/handle_user_input.c`.
* **Implementation of `process_command`**: Added `process_command` function to execute commands based on the AST in `src/main_loop/process_command.c`.

### File and Structure Updates:

* **Include `ast_node_t` definition**: Added `ast_node_t` typedef in `include/shell.h`.
* **Updated `src.list`**: Included `src/main_loop/handle_user_input.c` in the `src.list` file.