### PR TITLE
Lexer Test Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@
 .vscode
 *.txt
 
+##MAC
+.DS_Store
+*.swp
+*.swo
+
+
 .idea
 unit_tests
 42sh

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ HFILE_PATH = ./include/
 
 CFLAGS = -Wall -Wextra
 
-CRITERION = -lcriterion -lgcov --coverage -fprofile-arcs -ftest-coverage
+CRITERION = -lcriterion --coverage -fprofile-arcs -ftest-coverage
 
 BINARY = 42sh
 

--- a/tests/lexer/test_check_special_token.c
+++ b/tests/lexer/test_check_special_token.c
@@ -1,0 +1,35 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** test_check_special_token
+*/
+
+#include <criterion/criterion.h>
+#include "lexer.h"
+
+Test(check_special_token, should_find_token_and_return_index)
+{
+    cr_assert_eq(check_special_token("&& ls", 0), 2);
+    cr_assert_eq(check_special_token("|| echo", 0), 3);
+    cr_assert_eq(check_special_token(">> file", 0), 4);
+    cr_assert_eq(check_special_token("| grep", 0), 8);
+}
+
+Test(check_special_token, should_ignore_non_special_tokens)
+{
+    cr_assert_eq(check_special_token("abcd", 0), -1);
+    cr_assert_eq(check_special_token("echo", 0), -1);
+    cr_assert_eq(check_special_token("and", 0), -1);
+}
+
+Test(check_special_token, should_match_token_only_at_given_position)
+{
+    cr_assert_eq(check_special_token("ls && echo", 3), 2);
+    cr_assert_eq(check_special_token("ls && echo", 0), -1);
+}
+
+Test(check_special_token, should_not_crash_on_empty_string)
+{
+    cr_assert_eq(check_special_token("", 0), -1);
+}

--- a/tests/lexer/test_count_words.c
+++ b/tests/lexer/test_count_words.c
@@ -1,0 +1,46 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** test_count_words
+*/
+
+#include <criterion/criterion.h>
+#include "lexer.h"
+
+Test(count_words, should_count_simple_words)
+{
+    cr_assert_eq(count_words("echo hello", " "), 2);
+    cr_assert_eq(count_words("ls -la", " "), 2);
+}
+
+Test(count_words, should_handle_multiple_spaces)
+{
+    cr_assert_eq(count_words("  echo   test ", " "), 2);
+    cr_assert_eq(count_words("     ", " "), 0);
+}
+
+Test(count_words, should_count_special_tokens_as_words)
+{
+    cr_assert_eq(count_words("echo && ls", " "), 3); // echo, &&, ls
+    cr_assert_eq(count_words("a||b", " "), 3);       // a, ||, b
+    cr_assert_eq(count_words("x|y|z", " "), 5);      // x, |, y, |, z
+}
+
+Test(count_words, should_mix_words_and_special_tokens)
+{
+    cr_assert_eq(count_words("grep foo | wc -l", " "), 5); // grep, foo, |, wc, -l
+    cr_assert_eq(count_words("cmd1 && cmd2 || cmd3", " "), 5);
+}
+
+Test(count_words, should_return_zero_on_empty_input)
+{
+    cr_assert_eq(count_words("", " "), 0);
+    cr_assert_eq(count_words("   ", " "), 0);
+}
+
+// Test(count_words, should_handle_custom_delimiters)
+// {
+//     cr_assert_eq(count_words("a,b,c", ","), 3);
+//     cr_assert_eq(count_words("a;b&&c", ";"), 4); // a, b, &&, c
+// }

--- a/tests/lexer/test_count_words.c
+++ b/tests/lexer/test_count_words.c
@@ -22,14 +22,14 @@ Test(count_words, should_handle_multiple_spaces)
 
 Test(count_words, should_count_special_tokens_as_words)
 {
-    cr_assert_eq(count_words("echo && ls", " "), 3); // echo, &&, ls
-    cr_assert_eq(count_words("a||b", " "), 3);       // a, ||, b
-    cr_assert_eq(count_words("x|y|z", " "), 5);      // x, |, y, |, z
+    cr_assert_eq(count_words("echo && ls", " "), 3);
+    cr_assert_eq(count_words("a||b", " "), 3);
+    cr_assert_eq(count_words("x|y|z", " "), 5);
 }
 
 Test(count_words, should_mix_words_and_special_tokens)
 {
-    cr_assert_eq(count_words("grep foo | wc -l", " "), 5); // grep, foo, |, wc, -l
+    cr_assert_eq(count_words("grep foo | wc -l", " "), 5);
     cr_assert_eq(count_words("cmd1 && cmd2 || cmd3", " "), 5);
 }
 

--- a/tests/lexer/test_extract_word.c
+++ b/tests/lexer/test_extract_word.c
@@ -1,0 +1,38 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** test_extract_word
+*/
+
+#include <criterion/criterion.h>
+#include <string.h>
+#include "lexer.h"
+
+Test(extract_word, should_extract_correct_substring)
+{
+    char *result = extract_word("hello world", 0, 5);
+    cr_assert_str_eq(result, "hello");
+    free(result);
+}
+
+Test(extract_word, should_extract_word_from_middle)
+{
+    char *result = extract_word("hello world", 6, 5);
+    cr_assert_str_eq(result, "world");
+    free(result);
+}
+
+Test(extract_word, should_handle_partial_extraction)
+{
+    char *result = extract_word("criterion", 1, 4);
+    cr_assert_str_eq(result, "rite");
+    free(result);
+}
+
+Test(extract_word, should_return_empty_string_if_len_zero)
+{
+    char *result = extract_word("hello", 2, 0);
+    cr_assert_str_eq(result, "");
+    free(result);
+}

--- a/tests/lexer/test_handle_delimiter.c
+++ b/tests/lexer/test_handle_delimiter.c
@@ -1,0 +1,63 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** test_handle_delimiter
+*/
+
+#include <criterion/criterion.h>
+#include <string.h>
+#include <stdlib.h>
+#include "lexer.h"
+
+Test(handle_delimiter, should_start_new_word_on_non_delimiter)
+{
+    word_info_t info = {.start = -1, .word_idx = 0, .words = malloc(sizeof(char *) * 3)};
+    int i = 0;
+
+    char *line = "a";
+    char *delim = " ";
+
+    int ret = handle_delimiter(line, &i, &info, delim);
+
+    cr_assert_eq(ret, 0);
+    cr_assert_eq(info.start, 0);
+
+    free(info.words);
+}
+
+Test(handle_delimiter, should_finalize_word_on_delimiter)
+{
+    word_info_t info = {.start = 0, .word_idx = 0, .words = malloc(sizeof(char *) * 3)};
+    int i = 1;
+
+    char *line = "a ";
+    char *delim = " ";
+
+    int ret = handle_delimiter(line, &i, &info, delim);
+
+    cr_assert_eq(ret, 0);
+    cr_assert_eq(info.word_idx, 1);
+    cr_assert_str_eq(info.words[0], "a");
+    cr_assert_eq(info.start, -1);
+
+    free(info.words[0]);
+    free(info.words);
+}
+
+Test(handle_delimiter, should_do_nothing_on_delimiter_if_start_is_minus_one)
+{
+    word_info_t info = {.start = -1, .word_idx = 0, .words = malloc(sizeof(char *) * 3)};
+    int i = 0;
+
+    char *line = " ";
+    char *delim = " ";
+
+    int ret = handle_delimiter(line, &i, &info, delim);
+
+    cr_assert_eq(ret, 0);
+    cr_assert_eq(info.word_idx, 0);
+    cr_assert_eq(info.start, -1);
+
+    free(info.words);
+}

--- a/tests/lexer/test_handle_special_token.c
+++ b/tests/lexer/test_handle_special_token.c
@@ -1,0 +1,59 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** test_handle_special_token
+*/
+
+#include <criterion/criterion.h>
+#include <stdlib.h>
+#include <string.h>
+#include "lexer.h"
+
+Test(handle_special_token, should_add_only_special_token_if_no_word_in_progress)
+{
+    char *line = "&&";
+    int i = 0;
+    word_info_t info = {.start = -1, .word_idx = 0, .words = malloc(sizeof(char *) * 3)};
+
+    int ret = handle_special_token(line, &i, &info);
+
+    cr_assert_eq(ret, 0);
+    cr_assert_eq(info.word_idx, 1);
+    cr_assert_str_eq(info.words[0], "&&");
+    cr_assert_eq(i, 1);
+
+    free(info.words[0]);
+    free(info.words);
+}
+
+Test(handle_special_token, should_add_previous_word_then_special_token)
+{
+    char *line = "ls&&";
+    int i = 2;
+    word_info_t info = {.start = 0, .word_idx = 0, .words = malloc(sizeof(char *) * 3)};
+
+    int ret = handle_special_token(line, &i, &info);
+
+    cr_assert_eq(ret, 0);
+    cr_assert_eq(info.word_idx, 2);
+    cr_assert_str_eq(info.words[0], "ls");
+    cr_assert_str_eq(info.words[1], "&&");
+    cr_assert_eq(i, 3);
+
+    free(info.words[0]);
+    free(info.words[1]);
+    free(info.words);
+}
+
+Test(handle_special_token, should_return_84_if_not_a_special_token)
+{
+    char *line = "ls";
+    int i = 0;
+    word_info_t info = {.start = -1, .word_idx = 0, .words = malloc(sizeof(char *) * 3)};
+
+    int ret = handle_special_token(line, &i, &info);
+
+    cr_assert_eq(ret, 84);
+    free(info.words);
+}

--- a/tests/lexer/test_lexer.c
+++ b/tests/lexer/test_lexer.c
@@ -1,0 +1,54 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** test_lexer
+*/
+
+#include <criterion/criterion.h>
+#include <stdlib.h>
+#include <string.h>
+#include "lexer.h"
+
+Test(lexer, should_split_simple_command)
+{
+    char **tokens = lexer("ls -la");
+
+    cr_assert_not_null(tokens);
+    cr_assert_str_eq(tokens[0], "ls");
+    cr_assert_str_eq(tokens[1], "-la");
+    cr_assert_null(tokens[2]);
+
+    free(tokens[0]);
+    free(tokens[1]);
+    free(tokens);
+}
+
+Test(lexer, should_handle_special_token)
+{
+    char **tokens = lexer("echo && ls");
+
+    cr_assert_not_null(tokens);
+    cr_assert_str_eq(tokens[0], "echo");
+    cr_assert_str_eq(tokens[1], "&&");
+    cr_assert_str_eq(tokens[2], "ls");
+    cr_assert_null(tokens[3]);
+
+    for (int i = 0; i < 3; i++)
+        free(tokens[i]);
+    free(tokens);
+}
+
+Test(lexer, should_handle_command_with_trailing_word)
+{
+    char **tokens = lexer("echo test");
+
+    cr_assert_not_null(tokens);
+    cr_assert_str_eq(tokens[0], "echo");
+    cr_assert_str_eq(tokens[1], "test");
+    cr_assert_null(tokens[2]);
+
+    free(tokens[0]);
+    free(tokens[1]);
+    free(tokens);
+}

--- a/tests_src.list
+++ b/tests_src.list
@@ -6,3 +6,9 @@ tests/parser/tests_commands.c
 tests/parser/tests_pipes.c
 tests/parser/tests_and_or.c
 tests/parser/tests_sequence.c
+tests/lexer/test_check_special_token.c
+tests/lexer/test_count_words.c
+tests/lexer/test_extract_word.c
+tests/lexer/test_handle_delimiter.c
+tests/lexer/test_handle_special_token.c
+tests/lexer/test_lexer.c


### PR DESCRIPTION
This pull request includes several changes aimed at improving the test coverage for the lexer component of the project. The most significant changes involve adding new test cases for various lexer functions and updating the `Makefile` to refine the build configuration.

### Test Coverage Improvements:

* Added new test cases for `check_special_token` in `tests/lexer/test_check_special_token.c` to verify the handling of special tokens and their positions.
* Added new test cases for `count_words` in `tests/lexer/test_count_words.c` to ensure accurate word counting, including handling multiple spaces and special tokens.
* Added new test cases for `extract_word` in `tests/lexer/test_extract_word.c` to validate correct substring extraction from different positions.
* Added new test cases for `handle_delimiter` in `tests/lexer/test_handle_delimiter.c` to test word finalization and new word initiation based on delimiters.
* Added new test cases for `handle_special_token` in `tests/lexer/test_handle_special_token.c` to check the addition of special tokens and handling of non-special tokens.
* Added new test cases for `lexer` in `tests/lexer/test_lexer.c` to verify the splitting of simple commands and handling of special tokens.

### Build Configuration:

* Updated the `Makefile` to remove the redundant `-lgcov` flag from the `CRITERION` variable, streamlining the build process.