### PR TITLE
Add Environment Variable Management: Core Functions and Unit Tests

### DIFF
--- a/include/env.h
+++ b/include/env.h
@@ -1,0 +1,20 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** env
+*/
+
+#ifndef INCLUDED_ENV_H
+    #define INCLUDED_ENV_H
+    #include "shell.h"
+
+void free_shell(shell_t *shell);
+char *get_env_value(shell_t *shell, const char *var);
+shell_t *init_shell(char **env);
+void set_env_value(shell_t *shell, const char *var, const char *value);
+void unset_env_value(shell_t *shell, const char *var);
+
+
+
+#endif

--- a/include/shell.h
+++ b/include/shell.h
@@ -28,6 +28,7 @@ struct shell_s {
     char **env_array;
     int env_size;
     char **local_vars;
+    int local_size;
     int exit_code;
 };
 

--- a/include/shell.h
+++ b/include/shell.h
@@ -25,7 +25,8 @@ typedef struct command_s {
 // } redirection_t;
 
 struct shell_s {
-    char **env;
+    char **env_array;
+    int env_size;
     char **local_vars;
     int exit_code;
 };

--- a/src.list
+++ b/src.list
@@ -13,3 +13,8 @@ src/parser/parse_command.c
 src/parser/parse_sequence.c
 src/parser/parse_pipes.c
 src/parser/parse_and_or.c
+src/env/env_free.c
+src/env/env_get.c
+src/env/env_init.c
+src/env/env_set.c
+src/env/env_unset.c

--- a/src/env/env_free.c
+++ b/src/env/env_free.c
@@ -28,7 +28,7 @@ static void free_local_vars(shell_t *shell)
 
     if (!shell->local_vars)
         return;
-    while (i < shell->env_size) {
+    while (i < shell->local_size) {
         free(shell->local_vars[i]);
         i++;
     }

--- a/src/env/env_free.c
+++ b/src/env/env_free.c
@@ -1,0 +1,58 @@
+/*
+** EPITECH PROJECT, 2025
+** minishell_project
+** File description:
+** env_free
+*/
+
+#include <stdlib.h>
+#include "shell.h"
+
+
+static void free_env_array(shell_t *shell)
+{
+    int i = 0;
+
+    if (!shell->env_array)
+        return;
+    while (i < shell->env_size) {
+        free(shell->env_array[i]);
+        i++;
+    }
+    free(shell->env_array);
+}
+
+static void free_local_vars(shell_t *shell)
+{
+    int i = 0;
+
+    if (!shell->local_vars)
+        return;
+    while (i < shell->env_size) {
+        free(shell->local_vars[i]);
+        i++;
+    }
+    free(shell->local_vars);
+}
+
+static void free_cmd_args(char **cmd_args)
+{
+    int i = 0;
+
+    if (!cmd_args)
+        return;
+    while (cmd_args[i]) {
+        free(cmd_args[i]);
+        i++;
+    }
+    free(cmd_args);
+}
+
+void free_shell(shell_t *shell)
+{
+    if (!shell)
+        return;
+    free_env_array(shell);
+    free_local_vars(shell);
+    free(shell);
+}

--- a/src/env/env_get.c
+++ b/src/env/env_get.c
@@ -1,0 +1,29 @@
+/*
+** EPITECH PROJECT, 2025
+** minishell_project
+** File description:
+** env_get
+*/
+
+#include "shell.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+char *get_env_value(shell_t *shell, const char *var)
+{
+    int len;
+    int i = 0;
+
+    if (!shell || !var)
+        return NULL;
+    len = my_strlen(var);
+    while (i < shell->env_size) {
+        if (my_strncmp(shell->env_array[i], var, len) == 0 &&
+            shell->env_array[i][len] == '=') {
+            return shell->env_array[i] + len + 1;
+        }
+        i++;
+    }
+    return NULL;
+}

--- a/src/env/env_get.c
+++ b/src/env/env_get.c
@@ -17,9 +17,9 @@ char *get_env_value(shell_t *shell, const char *var)
 
     if (!shell || !var)
         return NULL;
-    len = my_strlen(var);
+    len = strlen(var);
     while (i < shell->env_size) {
-        if (my_strncmp(shell->env_array[i], var, len) == 0 &&
+        if (strncmp(shell->env_array[i], var, len) == 0 &&
             shell->env_array[i][len] == '=') {
             return shell->env_array[i] + len + 1;
         }

--- a/src/env/env_init.c
+++ b/src/env/env_init.c
@@ -1,0 +1,72 @@
+/*
+** EPITECH PROJECT, 2025
+** minishell_project
+** File description:
+** env_init
+*/
+
+#include "shell.h"
+#include <stdlib.h>
+#include <string.h>
+
+static int count_env_size(char **env)
+{
+    int size = 0;
+
+    while (env[size])
+        size++;
+    return size;
+}
+
+static void free_env_array_on_failure(char **env_array, int index)
+{
+    while (index > 0) {
+        free(env_array[index - 1]);
+        index--;
+    }
+    free(env_array);
+}
+
+static char **allocate_env_array(int env_size)
+{
+    char **env_array = malloc(sizeof(char *) * (env_size + 1));
+
+    if (!env_array)
+        return NULL;
+    return env_array;
+}
+
+static char **copy_env_array(char **env, int env_size)
+{
+    char **env_array = allocate_env_array(env_size);
+    int i = 0;
+
+    if (!env_array)
+        return NULL;
+    while (i < env_size) {
+        env_array[i] = strdup(env[i]);
+        if (!env_array[i]) {
+            free_env_array_on_failure(env_array, i);
+            return NULL;
+        }
+        i++;
+    }
+    env_array[env_size] = NULL;
+    return env_array;
+}
+
+shell_t *init_shell(char **env)
+{
+    shell_t *shell = malloc(sizeof(shell_t));
+
+    if (!shell)
+        return NULL;
+    shell->env_size = count_env_size(env);
+    shell->env_array = copy_env_array(env, shell->env_size);
+    if (!shell->env_array) {
+        free(shell);
+        return NULL;
+    }
+    shell->exit_code = 0;
+    return shell;
+}

--- a/src/env/env_set.c
+++ b/src/env/env_set.c
@@ -32,7 +32,7 @@ static int update_existing_env_var(shell_t *shell, const char *var,
 static int add_new_env_var(shell_t *shell, char *new_var)
 {
     size_t new_size = sizeof(char *) * (shell->env_size + 2);
-    char **new_env_array = realloc(shell->env_array, new_size); // a re-tester car avant my_realloc
+    char **new_env_array = realloc(shell->env_array, new_size);
 
     if (!new_env_array) {
         free(new_var);

--- a/src/env/env_set.c
+++ b/src/env/env_set.c
@@ -1,0 +1,65 @@
+/*
+** EPITECH PROJECT, 2025
+** minishell_project
+** File description:
+** env_set
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "shell.h"
+
+static int update_existing_env_var(shell_t *shell, const char *var,
+    char *new_var, int len)
+{
+    int i = 0;
+
+    while (i < shell->env_size) {
+        if (strncmp(shell->env_array[i], var, len) == 0 &&
+            shell->env_array[i][len] == '=') {
+            free(shell->env_array[i]);
+            shell->env_array[i] = new_var;
+            return 1;
+        }
+        i++;
+    }
+    return 0;
+}
+
+static int add_new_env_var(shell_t *shell, char *new_var)
+{
+    size_t new_size = sizeof(char *) * (shell->env_size + 2);
+    char **new_env_array = realloc(shell->env_array, new_size); // a re-tester car avant my_realloc
+
+    if (!new_env_array) {
+        free(new_var);
+        return 84;
+    }
+    shell->env_array = new_env_array;
+    shell->env_array[shell->env_size] = new_var;
+    shell->env_array[shell->env_size + 1] = NULL;
+    shell->env_size++;
+    return 0;
+}
+
+void set_env_value(shell_t *shell, const char *var, const char *value)
+{
+    char *new_var;
+    int len;
+
+    if (!shell || !var || !value)
+        return;
+    len = strlen(var);
+    new_var = malloc(len + strlen(value) + 2);
+    if (!new_var)
+        return;
+    strcpy(new_var, var);
+    strcat(new_var, "=");
+    strcat(new_var, value);
+    if (update_existing_env_var(shell, var, new_var, len))
+        return;
+    add_new_env_var(shell, new_var);
+}

--- a/src/env/env_unset.c
+++ b/src/env/env_unset.c
@@ -1,0 +1,49 @@
+/*
+** EPITECH PROJECT, 2025
+** minishell_project
+** File description:
+** env_unset
+*/
+
+#include "shell.h"
+#include <stdlib.h>
+#include <string.h>
+
+static int find_env_index(shell_t *shell, const char *var)
+{
+    int len = strlen(var);
+    int i = 0;
+
+    while (i < shell->env_size) {
+        if (strncmp(shell->env_array[i], var, len) == 0 &&
+            shell->env_array[i][len] == '=')
+            return i;
+        i++;
+    }
+    return -1;
+}
+
+static void shift_env_variables(shell_t *shell, int index)
+{
+    int i = index;
+
+    while (i < shell->env_size - 1) {
+        shell->env_array[i] = shell->env_array[i + 1];
+        i++;
+    }
+    shell->env_array[shell->env_size - 1] = NULL;
+    shell->env_size--;
+}
+
+void unset_env_value(shell_t *shell, const char *var)
+{
+    int index;
+
+    if (!shell || !var)
+        return;
+    index = find_env_index(shell, var);
+    if (index == -1)
+        return;
+    free(shell->env_array[index]);
+    shift_env_variables(shell, index);
+}

--- a/tests/env/test_env_free.c
+++ b/tests/env/test_env_free.c
@@ -1,0 +1,56 @@
+/*
+** EPITECH PROJECT, 2025
+** minishell_project
+** File description:
+** test_env_free
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/hooks.h>
+#include <stdlib.h>
+#include <string.h>
+#include "shell.h"
+#include "env.h"
+
+Test(free_shell, should_not_crash_if_shell_is_null)
+{
+    free_shell(NULL);
+    cr_assert(1); // Ne doit pas segfault
+}
+
+Test(free_shell, should_not_crash_if_env_array_is_null)
+{
+    shell_t *shell = malloc(sizeof(shell_t));
+    shell->env_array = NULL;
+    shell->local_vars = NULL;
+    shell->env_size = 0;
+
+    free_shell(shell);
+    cr_assert(1); // Ne doit pas segfault
+}
+
+Test(free_shell, should_free_env_array_properly)
+{
+    shell_t *shell = malloc(sizeof(shell_t));
+    shell->env_size = 2;
+    shell->env_array = malloc(sizeof(char *) * 2);
+    shell->env_array[0] = strdup("VAR1=value");
+    shell->env_array[1] = strdup("VAR2=value");
+    shell->local_vars = NULL;
+
+    free_shell(shell);
+    cr_assert(1); // Libération correcte sans crash
+}
+
+Test(free_shell, should_free_local_vars_properly)
+{
+    shell_t *shell = malloc(sizeof(shell_t));
+    shell->env_size = 2;
+    shell->local_vars = malloc(sizeof(char *) * 2);
+    shell->local_vars[0] = strdup("VAR1=local");
+    shell->local_vars[1] = strdup("VAR2=local");
+    shell->env_array = NULL;
+
+    free_shell(shell);
+    cr_assert(1);
+}

--- a/tests/env/test_env_get.c
+++ b/tests/env/test_env_get.c
@@ -1,0 +1,68 @@
+/*
+** EPITECH PROJECT, 2025
+** minishell_project
+** File description:
+** test_env_get
+*/
+
+#include <criterion/criterion.h>
+#include <stdlib.h>
+#include <string.h>
+#include "shell.h"
+#include "env.h"
+
+Test(get_env_value, should_return_value_for_existing_variable)
+{
+    shell_t shell;
+    shell.env_size = 2;
+    shell.env_array = malloc(sizeof(char *) * 2);
+    shell.env_array[0] = strdup("USER=loann");
+    shell.env_array[1] = strdup("PATH=/usr/bin");
+
+    char *result = get_env_value(&shell, "USER");
+    cr_assert_str_eq(result, "loann");
+
+    free(shell.env_array[0]);
+    free(shell.env_array[1]);
+    free(shell.env_array);
+}
+
+Test(get_env_value, should_return_null_for_nonexistent_variable)
+{
+    shell_t shell;
+    shell.env_size = 2;
+    shell.env_array = malloc(sizeof(char *) * 2);
+    shell.env_array[0] = strdup("USER=loann");
+    shell.env_array[1] = strdup("PATH=/usr/bin");
+
+    char *result = get_env_value(&shell, "HOME");
+    cr_assert_null(result);
+
+    free(shell.env_array[0]);
+    free(shell.env_array[1]);
+    free(shell.env_array);
+}
+
+Test(get_env_value, should_return_null_if_var_is_null)
+{
+    shell_t shell = {.env_array = NULL, .env_size = 0};
+    cr_assert_null(get_env_value(&shell, NULL));
+}
+
+Test(get_env_value, should_return_null_if_shell_is_null)
+{
+    cr_assert_null(get_env_value(NULL, "PATH"));
+}
+
+Test(get_env_value, should_not_match_prefix_only)
+{
+    shell_t shell;
+    shell.env_size = 1;
+    shell.env_array = malloc(sizeof(char *) * 1);
+    shell.env_array[0] = strdup("PATHWAY=/some/dir");
+
+    cr_assert_null(get_env_value(&shell, "PATH"));
+
+    free(shell.env_array[0]);
+    free(shell.env_array);
+}

--- a/tests/env/test_env_init.c
+++ b/tests/env/test_env_init.c
@@ -1,0 +1,44 @@
+/*
+** EPITECH PROJECT, 2025
+** minishell_project
+** File description:
+** test_env_init
+*/
+
+#include <criterion/criterion.h>
+#include <stdlib.h>
+#include <string.h>
+#include "shell.h"
+#include "env.h"
+
+Test(init_shell, should_initialize_shell_with_env)
+{
+    char *env[] = {"USER=loann", "PATH=/usr/bin", NULL};
+    shell_t *shell = init_shell(env);
+
+    cr_assert_not_null(shell);
+    cr_assert_eq(shell->env_size, 2);
+    cr_assert_str_eq(shell->env_array[0], "USER=loann");
+    cr_assert_str_eq(shell->env_array[1], "PATH=/usr/bin");
+    cr_assert_null(shell->env_array[2]);
+    cr_assert_eq(shell->exit_code, 0);
+
+    free(shell->env_array[0]);
+    free(shell->env_array[1]);
+    free(shell->env_array);
+    free(shell);
+}
+
+Test(init_shell, should_handle_empty_env)
+{
+    char *env[] = {NULL};
+    shell_t *shell = init_shell(env);
+
+    cr_assert_not_null(shell);
+    cr_assert_eq(shell->env_size, 0);
+    cr_assert_not_null(shell->env_array);
+    cr_assert_null(shell->env_array[0]);
+
+    free(shell->env_array);
+    free(shell);
+}

--- a/tests/env/test_env_set.c
+++ b/tests/env/test_env_set.c
@@ -1,0 +1,68 @@
+/*
+** EPITECH PROJECT, 2025
+** minishell_project
+** File description:
+** test_env_set
+*/
+
+#include <criterion/criterion.h>
+#include <stdlib.h>
+#include <string.h>
+#include "shell.h"
+#include "env.h"
+
+Test(set_env_value, should_add_new_variable)
+{
+    shell_t shell = {
+        .env_array = malloc(sizeof(char *) * 1),
+        .env_size = 0
+    };
+    shell.env_array[0] = NULL;
+
+    set_env_value(&shell, "EDITOR", "vim");
+
+    cr_assert_eq(shell.env_size, 1);
+    cr_assert_str_eq(shell.env_array[0], "EDITOR=vim");
+    cr_assert_null(shell.env_array[1]);
+
+    free(shell.env_array[0]);
+    free(shell.env_array);
+}
+
+Test(set_env_value, should_update_existing_variable)
+{
+    shell_t shell = {
+        .env_size = 1,
+        .env_array = malloc(sizeof(char *) * 2)
+    };
+    shell.env_array[0] = strdup("EDITOR=nano");
+    shell.env_array[1] = NULL;
+
+    set_env_value(&shell, "EDITOR", "vim");
+
+    cr_assert_eq(shell.env_size, 1);
+    cr_assert_str_eq(shell.env_array[0], "EDITOR=vim");
+
+    free(shell.env_array[0]);
+    free(shell.env_array);
+}
+
+Test(set_env_value, should_ignore_null_shell)
+{
+    set_env_value(NULL, "FOO", "BAR");
+    cr_assert(1); // Ne doit pas segfault
+}
+
+Test(set_env_value, should_ignore_null_var)
+{
+    shell_t shell = {.env_size = 0, .env_array = NULL};
+    set_env_value(&shell, NULL, "value");
+    cr_assert(1); // Ne doit pas segfault
+}
+
+Test(set_env_value, should_ignore_null_value)
+{
+    shell_t shell = {.env_size = 0, .env_array = NULL};
+    set_env_value(&shell, "VAR", NULL);
+    cr_assert(1); // Ne doit pas segfault
+}

--- a/tests/env/test_env_unset.c
+++ b/tests/env/test_env_unset.c
@@ -1,0 +1,80 @@
+/*
+** EPITECH PROJECT, 2025
+** minishell_project
+** File description:
+** test_env_unset
+*/
+
+#include <criterion/criterion.h>
+#include <stdlib.h>
+#include <string.h>
+#include "shell.h"
+#include "env.h"
+
+Test(unset_env_value, should_remove_existing_variable)
+{
+    shell_t shell;
+    shell.env_size = 3;
+    shell.env_array = malloc(sizeof(char *) * 4);
+    shell.env_array[0] = strdup("USER=loann");
+    shell.env_array[1] = strdup("PATH=/bin");
+    shell.env_array[2] = strdup("EDITOR=nano");
+    shell.env_array[3] = NULL;
+
+    unset_env_value(&shell, "PATH");
+
+    cr_assert_eq(shell.env_size, 2);
+    cr_assert_str_eq(shell.env_array[0], "USER=loann");
+    cr_assert_str_eq(shell.env_array[1], "EDITOR=nano");
+    cr_assert_null(shell.env_array[2]);
+
+    free(shell.env_array[0]);
+    free(shell.env_array[1]);
+    free(shell.env_array);
+}
+
+Test(unset_env_value, should_do_nothing_if_variable_does_not_exist)
+{
+    shell_t shell;
+    shell.env_size = 2;
+    shell.env_array = malloc(sizeof(char *) * 3);
+    shell.env_array[0] = strdup("USER=loann");
+    shell.env_array[1] = strdup("EDITOR=vim");
+    shell.env_array[2] = NULL;
+
+    unset_env_value(&shell, "PATH");
+
+    cr_assert_eq(shell.env_size, 2);
+    cr_assert_str_eq(shell.env_array[0], "USER=loann");
+    cr_assert_str_eq(shell.env_array[1], "EDITOR=vim");
+    cr_assert_null(shell.env_array[2]);
+
+    free(shell.env_array[0]);
+    free(shell.env_array[1]);
+    free(shell.env_array);
+}
+
+Test(unset_env_value, should_handle_null_shell_and_var)
+{
+    unset_env_value(NULL, "FOO");
+    unset_env_value(&(shell_t){0}, NULL);
+    cr_assert(1); // Ne doit pas segfault
+}
+
+Test(unset_env_value, should_not_match_prefix_only)
+{
+    shell_t shell;
+    shell.env_size = 1;
+    shell.env_array = malloc(sizeof(char *) * 2);
+    shell.env_array[0] = strdup("PATHWAY=/weird/path");
+    shell.env_array[1] = NULL;
+
+    unset_env_value(&shell, "PATH");
+
+    cr_assert_eq(shell.env_size, 1);
+    cr_assert_str_eq(shell.env_array[0], "PATHWAY=/weird/path");
+    cr_assert_null(shell.env_array[1]);
+
+    free(shell.env_array[0]);
+    free(shell.env_array);
+}

--- a/tests_src.list
+++ b/tests_src.list
@@ -13,3 +13,5 @@ tests/lexer/test_handle_delimiter.c
 tests/lexer/test_handle_special_token.c
 tests/lexer/test_lexer.c
 tests/env/test_env_free.c
+tests/env/test_env_get.c
+tests/env/test_env_init.c

--- a/tests_src.list
+++ b/tests_src.list
@@ -16,3 +16,4 @@ tests/env/test_env_free.c
 tests/env/test_env_get.c
 tests/env/test_env_init.c
 tests/env/test_env_set.c
+tests/env/test_env_unset.c

--- a/tests_src.list
+++ b/tests_src.list
@@ -15,3 +15,4 @@ tests/lexer/test_lexer.c
 tests/env/test_env_free.c
 tests/env/test_env_get.c
 tests/env/test_env_init.c
+tests/env/test_env_set.c

--- a/tests_src.list
+++ b/tests_src.list
@@ -12,3 +12,4 @@ tests/lexer/test_extract_word.c
 tests/lexer/test_handle_delimiter.c
 tests/lexer/test_handle_special_token.c
 tests/lexer/test_lexer.c
+tests/env/test_env_free.c


### PR DESCRIPTION
This pull request introduces a series of changes to enhance the environment variable handling in the shell project. The changes include adding new functionality for managing environment variables, updating existing structures, and adding tests for the new functions.

### Enhancements to environment variable handling:

* **New functions for environment management**:
  - Added `free_shell`, `get_env_value`, `init_shell`, `set_env_value`, and `unset_env_value` functions to `include/env.h` for managing environment variables.
  - Implemented `free_shell` in `src/env/env_free.c` to release memory allocated for the shell structure and its environment variables.
  - Implemented `get_env_value` in `src/env/env_get.c` to retrieve the value of a specified environment variable.
  - Implemented `init_shell` in `src/env/env_init.c` to initialize the shell structure with environment variables.
  - Implemented `set_env_value` in `src/env/env_set.c` to set or update an environment variable.
  - Implemented `unset_env_value` in `src/env/env_unset.c` to remove an environment variable.

* **Updates to shell structure**:
  - Modified `shell_s` structure in `include/shell.h` to include `env_array` and `env_size` for better management of environment variables.

### Test additions:

* **New test files for environment management**:
  - Added tests for `free_shell` in `tests/env/test_env_free.c` to ensure proper memory deallocation.
  - Added tests for `get_env_value` in `tests/env/test_env_get.c` to verify correct retrieval of environment variables.
  - Added tests for `init_shell` in `tests/env/test_env_init.c` to check initialization of the shell with environment variables.
  - Added tests for `set_env_value` in `tests/env/test_env_set.c` to confirm setting and updating of environment variables.
  - Added tests for `unset_env_value` in `tests/env/test_env_unset.c` to validate removal of environment variables.