### PR TITLE
refactor(execute_functions): redeclaration of execute_function array

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -74,17 +74,6 @@ struct ast_node_s {
     data_t data;
 };
 
-extern int (*execute_functions[])(ast_node_t *, shell_t *);
-
-
-/*
-    [NODE_PIPE] = execute_pipe,
-    [NODE_REDIRECT] = execute_redirect,
-    [NODE_SEQUENCE] = execute_sequence,
-    [NODE_AND] = execute_and,
-    [NODE_OR] = execute_or
-*/
-
 ast_node_t *parse_sequence(char **tokens, int *pos);
 ast_node_t *parse_pipes(char **tokens, int *pos);
 ast_node_t *parse_redirect(char **tokens, int *pos);

--- a/src/main_loop/process_command.c
+++ b/src/main_loop/process_command.c
@@ -8,19 +8,11 @@
 #include "ast.h"
 #include <stdio.h>
 
-const int (*execute_functions[])(ast_node_t *, shell_t *) = {
-    [NODE_COMMAND] = execute_command,
-    /*
-    [NODE_PIPE] = execute_pipe,
-    [NODE_REDIRECT] = execute_redirect,
-    [NODE_SEQUENCE] = execute_sequence,
-    [NODE_AND] = execute_and,
-    [NODE_OR] = execute_or,
-    [NODE_SUBSHELL] = execute_subshell,
-    */
-};
-
 void process_command(ast_node_t *ast, shell_t *shell_info)
 {
+    static int (*execute_functions[])(ast_node_t *, shell_t *) = {
+        [NODE_COMMAND] = execute_command,
+    };
+
     execute_functions[ast->type](ast, shell_info);
 }


### PR DESCRIPTION
This pull request includes changes to the `include/ast.h` and `src/main_loop/process_command.c` files to refactor the way execute functions are handled and improve the structure of the code.

Refactoring of execute functions:

* [`include/ast.h`](diffhunk://#diff-0e94326f4ee73cf3526bc77ef5dca7bc74a919aa7ddd33eff55e04a251090bc1L77-L87): Removed the declaration of the `execute_functions` array and the commented-out function assignments.
* [`src/main_loop/process_command.c`](diffhunk://#diff-a0ee54e7a7b25cb7408c5c894298d4045389caed344220a980ef3f7693afa273L11-L24): Moved the `execute_functions` array inside the `process_command` function and changed its declaration to `static`. Removed the commented-out function assignments.