### PR TITLE
feat(command): add PATH env handling for command without /path/

### DIFF
--- a/include/command.h
+++ b/include/command.h
@@ -8,13 +8,23 @@
 #ifndef INCLUDED_COMMAND_H
     #define INCLUDED_COMMAND_H
     #include "shell.h"
+    #include "ast.h"
     #include <sys/types.h>
+
+typedef enum redirect_type_e redirect_type_t;
+
 typedef struct command_info_s {
     int command_count;
     ast_node_t **commands;
     pid_t *pids;
     int (*pipes)[2];
 } command_info_t;
+
+typedef struct path_search_s {
+    char *command;
+    char *result_path;
+    shell_t *shell;
+} path_search_t;
 
 // Utility functions
 void handle_command_not_found(char *command);
@@ -27,5 +37,9 @@ int execute_or(ast_node_t *ast, shell_t *shell_info);
 int execute_and(ast_node_t *ast, shell_t *shell_info);
 int execute_sequence(ast_node_t *ast, shell_t *shell_info);
 int execute_redirect(ast_node_t *node, struct shell_s *shell_var);
+void (*get_redirect_handler(redirect_type_t type))(char *);
+
+char *build_path(shell_t *shell, char *command);
+char *my_strcat(char *dest, char const *str);
 
 #endif

--- a/src.list
+++ b/src.list
@@ -30,3 +30,6 @@ src/env/env_unset.c
 src/env/local_get.c
 src/env/local_set.c
 src/env/local_unset.c
+src/command_execution/get_command_path.c
+src/utils/strcat.c
+src/command_execution/get_redirect_handler.c

--- a/src/command_execution/execute_command.c
+++ b/src/command_execution/execute_command.c
@@ -22,12 +22,13 @@ int execute_command(ast_node_t *node, struct shell_s *shell_var)
 {
     pid_t pid;
     int status;
+    char *full_path = build_path(shell_var, node->data.command->argv[0]);
 
     if (is_builtin_cmd(node))
         return -1;
     pid = fork();
     if (pid == 0) {
-        execve(node->data.command->argv[0], node->data.command->argv,
+        execve(full_path, node->data.command->argv,
             shell_var->env_array);
         handle_command_not_found(node->data.command->argv[0]);
     }

--- a/src/command_execution/execute_pipe_command.c
+++ b/src/command_execution/execute_pipe_command.c
@@ -69,16 +69,18 @@ static void close_pipes(int pipes[][2], int count)
 }
 
 static int execute_child_command(command_info_t *command_info, int i,
-    struct shell_s *shell_var)
+    shell_t *shell_var)
 {
-    if (is_builtin_cmd(command_info->commands[i]))
+    ast_node_t *node = command_info->commands[i];
+    char *full_path = build_path(shell_var, node->data.command->argv[0]);
+
+    if (is_builtin_cmd(node) || !full_path)
         return -1;
     if (command_info->pids[i] == 0) {
-        execve(command_info->commands[i]->data.command->argv[0],
-            command_info->commands[i]->data.command->argv,
+        execve(full_path,
+            node->data.command->argv,
             shell_var->env_array);
-        handle_command_not_found
-        (command_info->commands[i]->data.command->argv[0]);
+        handle_command_not_found(node->data.command->argv[0]);
     }
     return -1;
 }

--- a/src/command_execution/get_command_path.c
+++ b/src/command_execution/get_command_path.c
@@ -1,0 +1,141 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** get_command_path
+*/
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include "shell.h"
+#include "command.h"
+
+/**
+ * @brief Expand tilde (~) in path to home directory
+ * @param path Path that may contain tilde
+ * @return Newly allocated string with expanded path or NULL
+ */
+static char *expand_tilde(const char *path)
+{
+    char *expanded_path = NULL;
+    char *tmp = NULL;
+    const char *home = getenv("HOME");
+
+    if (!home || path[0] != '~')
+        return strdup(path);
+    expanded_path = strdup(home);
+    if (!expanded_path)
+        return NULL;
+    tmp = my_strcat(expanded_path, path + 1);
+    free(expanded_path);
+    return tmp;
+}
+
+/**
+ * @brief Build a full path by combining directory and command
+ * @param dir Directory path
+ * @param command Command name
+ * @return Newly allocated full path or NULL
+ */
+static char *build_full_path(char *dir, char *command)
+{
+    char *path_with_slash = NULL;
+    char *full_path = NULL;
+
+    path_with_slash = my_strcat(dir, "/");
+    if (!path_with_slash)
+        return NULL;
+    full_path = my_strcat(path_with_slash, command);
+    free(path_with_slash);
+    return full_path;
+}
+
+/**
+ * @brief Check if path is accessible and update search structure
+ * @param path Path to check
+ * @param search Search structure to update
+ * @return 0 if path exists and is accessible, 1 otherwise
+ */
+static int check_path_access(char *path, path_search_t *search)
+{
+    if (access(path, F_OK) == 0) {
+        search->result_path = path;
+        return 0;
+    }
+    return 1;
+}
+
+/**
+ * @brief Process a single PATH directory token
+ * @param token Directory from PATH
+ * @param search Search structure
+ * @return 0 if command found, 1 otherwise
+ */
+static int process_path_token(char *token, path_search_t *search)
+{
+    char *expanded_dir = NULL;
+    char *full_path = NULL;
+    int result;
+
+    expanded_dir = expand_tilde(token);
+    if (!expanded_dir)
+        return 1;
+    full_path = build_full_path(expanded_dir, search->command);
+    free(expanded_dir);
+    if (!full_path)
+        return 1;
+    result = check_path_access(full_path, search);
+    if (result != 0)
+        free(full_path);
+    return result;
+}
+
+/**
+ * @brief Check command in all PATH directories
+ * @param path_str PATH environment variable
+ * @param search Search structure
+ * @return 0 if command found, 1 otherwise
+ */
+static int check_command_in_path(char *path_str, path_search_t *search)
+{
+    char *path_copy = strdup(path_str);
+    char *token = NULL;
+    int result = 1;
+
+    if (!path_copy)
+        return 1;
+    token = strtok(path_copy, ":");
+    while (token) {
+        if (process_path_token(token, search) == 0) {
+            result = 0;
+            break;
+        }
+        token = strtok(NULL, ":");
+    }
+    free(path_copy);
+    return result;
+}
+
+/**
+ * @brief Search for command in PATH
+ * @param shell Shell context
+ * @param command Command to search for
+ * @return 0 if command found, 1 otherwise
+ */
+char *build_path(shell_t *shell, char *command)
+{
+    char *path = getenv("PATH");
+    path_search_t search = {0};
+    int result;
+
+    if (!path)
+        path = DEFAULT_PATH;
+    search.command = command;
+    search.shell = shell;
+    search.result_path = NULL;
+    result = check_command_in_path(path, &search);
+    if (result == 0)
+        return search.result_path;
+    return command;
+}

--- a/src/command_execution/get_redirect_handler.c
+++ b/src/command_execution/get_redirect_handler.c
@@ -1,0 +1,23 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** get_redirect_handler
+*/
+
+#include "ast.h"
+#include "redirect_cmd.h"
+
+void (*get_redirect_handler(redirect_type_t type))(char *)
+{
+    static void (*handlers[])(char *) = {
+        [REDIR_NONE] = NULL,
+        [REDIR_OUT] = handle_output_redirection,
+        [REDIR_APPEND] = handle_append_redirection,
+        [REDIR_IN] = handle_input_redirection,
+        [REDIR_HEREDOC] = handle_heredoc_redirection,
+    };
+
+    return (type >= REDIR_NONE && type <= REDIR_HEREDOC) ?
+        handlers[type] : NULL;
+}

--- a/src/env/env_free.c
+++ b/src/env/env_free.c
@@ -35,19 +35,6 @@ static void free_local_vars(shell_t *shell)
     free(shell->local_vars);
 }
 
-static void free_cmd_args(char **cmd_args)
-{
-    int i = 0;
-
-    if (!cmd_args)
-        return;
-    while (cmd_args[i]) {
-        free(cmd_args[i]);
-        i++;
-    }
-    free(cmd_args);
-}
-
 void free_shell(shell_t *shell)
 {
     if (!shell)

--- a/src/main.c
+++ b/src/main.c
@@ -37,12 +37,10 @@ static void main_loop(shell_t *shell_info)
     }
 }
 
-int main(int argc, char **argv, char **env)
+int main(void)
 {
     shell_t *shell_info = malloc(sizeof(shell_t));
 
-    (void)argc;
-    (void)argv;
     main_loop(shell_info);
     return 0;
 }

--- a/src/main_loop/process_command.c
+++ b/src/main_loop/process_command.c
@@ -20,5 +20,7 @@ int process_command(ast_node_t *ast, shell_t *shell_info)
         [NODE_REDIRECT] = execute_redirect,
     };
 
+    if (ast == NULL)
+        return 0;
     return execute_functions[ast->type](ast, shell_info);
 }

--- a/src/utils/strcat.c
+++ b/src/utils/strcat.c
@@ -1,0 +1,33 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** strcat
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+/**
+ * @brief Concatenate two strings
+ * @param dest First string
+ * @param str Second string
+ * @return Newly allocated string with concatenated result
+ */
+char *my_strcat(char *dest, char *str)
+{
+    int i = 0;
+    int len = strlen(dest);
+    char *result = malloc(sizeof(char) * (len + strlen(str) + 1));
+
+    if (!result)
+        return NULL;
+    strcpy(result, dest);
+    while (str[i] != '\0') {
+        result[len + i] = str[i];
+        i++;
+    }
+    result[len + i] = '\0';
+    return result;
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to command execution and redirection handling in the shell, alongside utility improvements and minor cleanup. The most important changes include the addition of a `build_path` function for resolving command paths, a new `get_redirect_handler` function for handling redirections, and various refactoring efforts to simplify and streamline the codebase.

### Command Execution Enhancements:
* Added `build_path` function to resolve the full path of commands using the `PATH` environment variable, with support for tilde expansion and path accessibility checks (`src/command_execution/get_command_path.c`, [[1]](diffhunk://#diff-d37a73b7da38fb2014a93a16ee2e6515b9d6b995b564cd10748423221c7b2210R1-R141). Integrated this function into `execute_command` and `execute_child_command` to replace direct calls to `execve` with resolved paths (`src/command_execution/execute_command.c`, [[2]](diffhunk://#diff-7ec179470b999a33a88970541215902260c01608c289785c39dc2c8c18cc1e88R25-R31); `src/command_execution/execute_pipe_command.c`, [[3]](diffhunk://#diff-1ca0f1ef449527a8a630a9e6a93bbd17f98ed8e69f6c2f9253b93484c69cbceaL72-R83).

### Redirection Handling Improvements:
* Replaced the static `redirect_handlers` array with a new `get_redirect_handler` function, which dynamically retrieves the appropriate handler for a given redirection type (`src/command_execution/get_redirect_handler.c`, [[1]](diffhunk://#diff-2cc564e46c700c630f5b1851586d8b4b1403fd847ed20da3f25a45e27a1c6560R1-R23). Updated `execute_redirect` to use this function, improving error handling for invalid redirection types (`src/command_execution/execute_redirect_command.c`, [[2]](diffhunk://#diff-fa78aefe3bb8c3156785e4037630db2361859aa3acf6f5ffe94b9dec486384faR79-R88).

### Utility Additions:
* Implemented a `my_strcat` utility function for safe string concatenation, used in path-building operations (`src/utils/strcat.c`, [src/utils/strcat.cR1-R33](diffhunk://#diff-ab798956ccf0c00d4a966f4a6176c9e1054d902908f79df0228eac2517ca6b02R1-R33)).

### Codebase Refactoring:
* Removed unused `free_cmd_args` function from `env_free.c` to clean up redundant code (`src/env/env_free.c`, [src/env/env_free.cL38-L50](diffhunk://#diff-f103cbb34bc6869b7a92dc62358c8fc0b64d99666272addea87923c805a8a1beL38-L50)).
* Simplified the `main` function by removing unused parameters (`src/main.c`, [src/main.cL40-L45](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L40-L45)).

### Bug Fix:
* Added a null check for the `ast` parameter in `process_command` to prevent potential segmentation faults (`src/main_loop/process_command.c`, [src/main_loop/process_command.cR23-R24](diffhunk://#diff-a0ee54e7a7b25cb7408c5c894298d4045389caed344220a980ef3f7693afa273R23-R24)).