### PR TITLE
fix(execute_pipe_command) : Fix waitpid placement in the function

### DIFF
--- a/src/command_execution/execute_pipe_command.c
+++ b/src/command_execution/execute_pipe_command.c
@@ -163,8 +163,8 @@ int execute_pipe(ast_node_t *node, struct shell_s *shell_var)
         cleanup_command_info(command_info);
         return -1;
     }
-    waitpid(command_info->pids[command_info->command_count], &status, 0);
     close_pipes(command_info->pipes, command_info->command_count - 1);
+    waitpid(command_info->pids[command_info->command_count - 1], &status, 0);
     cleanup_command_info(command_info);
     return 0;
 }


### PR DESCRIPTION
Correct waitpid call to use the last command's PID in pipe execution.
The problem was that sometimes, the prompt was printed before the result of the last command in the pipe segment.