### PR TITLE
fix (command_execution): add modifications to the exit code value whe…

### DIFF
--- a/include/command.h
+++ b/include/command.h
@@ -43,6 +43,7 @@ int execute_and(ast_node_t *ast, shell_t *shell_info);
 int execute_sequence(ast_node_t *ast, shell_t *shell_info);
 int execute_redirect(ast_node_t *node, struct shell_s *shell_var);
 void (*get_redirect_handler(redirect_type_t type))(char *);
+int execute_builtin(ast_node_t *node, struct shell_s *shell_var);
 
 char *build_path(shell_t *shell, char *command);
 char *my_strcat(char *dest, char const *str);

--- a/src/builtins/builtin_setenv.c
+++ b/src/builtins/builtin_setenv.c
@@ -61,11 +61,11 @@ static int print_environment(shell_t *shell)
 int builtin_setenv(shell_t *shell, char **args)
 {
     if (!shell || !args || !args[0])
-        return 84;
+        return 1;
     if (!args[1])
         return print_environment(shell);
     if (handle_setenv_errors(shell, args) != 0)
-        return 84;
+        return 1;
     set_env_value(shell, args[1], args[2] ? args[2] : "");
     return 0;
 }

--- a/src/builtins/builtin_unsetenv.c
+++ b/src/builtins/builtin_unsetenv.c
@@ -15,16 +15,16 @@
 int builtin_unsetenv(shell_t *shell, char **args)
 {
     if (!shell || !args || !args[0])
-        return 84;
+        return 1;
     if (!args[1]) {
         printf("unsetenv: Too few arguments.\n");
         shell->exit_code = 1;
-        return 84;
+        return 1;
     }
     if (args[2]) {
         printf("unsetenv: Too many arguments.\n");
         shell->exit_code = 1;
-        return 84;
+        return 1;
     }
     unset_env_value(shell, args[1]);
     return 0;

--- a/src/command_execution/execute_command.c
+++ b/src/command_execution/execute_command.c
@@ -25,20 +25,28 @@ static void child_process(
     handle_command_not_found(node->data.command->argv[0]);
 }
 
-int execute_command(ast_node_t *node, struct shell_s *shell_var)
+int execute_builtin(ast_node_t *node, struct shell_s *shell_var)
 {
     const builtin_t *builtins = get_builtins();
-    pid_t pid;
-    int status;
-    char *full_path = build_path(shell_var, node->data.command->argv[0]);
 
     for (int i = 0; builtins[i].name != NULL; i++) {
         if (strcmp(node->data.command->argv[0], builtins[i].name) == 0)
             return builtins[i].func(shell_var, node->data.command->argv);
     }
-    pid = fork();
-    if (pid == 0)
+    
+    return -1;
+}
+
+static int execute_external_command(
+    char *full_path, ast_node_t *node, struct shell_s *shell_var)
+{
+    pid_t pid = fork();
+    int status;
+
+    if (pid == 0) {
         child_process(full_path, node, shell_var);
+        exit(1);
+    }
     waitpid(pid, &status, 0);
     if (WIFEXITED(status))
         return WEXITSTATUS(status);
@@ -47,4 +55,18 @@ int execute_command(ast_node_t *node, struct shell_s *shell_var)
         return 128 + WTERMSIG(status);
     }
     return 0;
+}
+
+int execute_command(ast_node_t *node, struct shell_s *shell_var)
+{
+    char *full_path = build_path(shell_var, node->data.command->argv[0]);
+    int result = execute_builtin(node, shell_var);
+
+    if (result != -1) {
+        free(full_path);
+        return result;
+    }
+    result = execute_external_command(full_path, node, shell_var);
+    free(full_path);
+    return result;
 }

--- a/src/command_execution/execute_command.c
+++ b/src/command_execution/execute_command.c
@@ -33,7 +33,6 @@ int execute_builtin(ast_node_t *node, struct shell_s *shell_var)
         if (strcmp(node->data.command->argv[0], builtins[i].name) == 0)
             return builtins[i].func(shell_var, node->data.command->argv);
     }
-    
     return -1;
 }
 

--- a/src/command_execution/execute_command.c
+++ b/src/command_execution/execute_command.c
@@ -42,6 +42,10 @@ static int execute_external_command(
     pid_t pid = fork();
     int status;
 
+    if (pid == -1) {
+        perror("fork failed");
+        return -1;
+    }
     if (pid == 0) {
         child_process(full_path, node, shell_var);
         exit(1);

--- a/src/main.c
+++ b/src/main.c
@@ -41,10 +41,12 @@ static void main_loop(shell_t *shell_info)
 int main(int argc, char **argv, char **env)
 {
     shell_t *shell = init_shell(env);
+    int exit_code;
 
     (void)argc;
     (void)argv;
     main_loop(shell);
+    exit_code = shell->exit_code;
     free_shell(shell);
-    return shell->exit_code;
+    return exit_code;
 }

--- a/src/main_loop/process_command.c
+++ b/src/main_loop/process_command.c
@@ -22,5 +22,6 @@ int process_command(ast_node_t *ast, shell_t *shell_info)
 
     if (ast == NULL)
         return 0;
-    return execute_functions[ast->type](ast, shell_info);
+    shell_info->exit_code = execute_functions[ast->type](ast, shell_info);
+    return shell_info->exit_code;
 }


### PR DESCRIPTION
This pull request introduces several changes to improve the structure and error handling of the shell command execution process. The key updates include separating built-in and external command execution, standardizing exit codes, and ensuring consistent handling of the shell's exit code.

### Command Execution Refactoring:
* Introduced a new `execute_builtin` function to handle built-in command execution separately from external commands. This improves modularity by delegating external command execution to a new `execute_external_command` function. (`include/command.h`, `src/command_execution/execute_command.c`) [[1]](diffhunk://#diff-55a851fad0e062933f846843e70b8e6ce9f2877c993f44104053cf1f285afa4bR46) [[2]](diffhunk://#diff-7ec179470b999a33a88970541215902260c01608c289785c39dc2c8c18cc1e88L28-R49) [[3]](diffhunk://#diff-7ec179470b999a33a88970541215902260c01608c289785c39dc2c8c18cc1e88R59-R72)

### Standardized Exit Codes:
* Updated built-in commands `builtin_setenv` and `builtin_unsetenv` to return `1` instead of `84` for error cases, aligning with standard exit code conventions. (`src/builtins/builtin_setenv.c`, `src/builtins/builtin_unsetenv.c`) [[1]](diffhunk://#diff-b9a37d6e6e71a8fc8175dc7a6d02ac7d4a10a96aaa01545a176ffdee5b3cd529L64-R68) [[2]](diffhunk://#diff-b9c7dcddd9afb1da0450edff433bd2814df7de69f4f2cf707cac2a3be45bff6aL18-R27)

### Shell Exit Code Handling:
* Modified the `main` function to store the shell's exit code in a local variable before freeing resources, ensuring proper return value. (`src/main.c`)
* Updated `process_command` to explicitly set the shell's `exit_code` after executing a command, ensuring consistent state management. (`src/main_loop/process_command.c`)…n there is an error in the command execution