### PR TITLE
tests: add ast building and command reading test

### DIFF
--- a/tests/parser/tests_ast_build.c
+++ b/tests/parser/tests_ast_build.c
@@ -2,18 +2,19 @@
 ** EPITECH PROJECT, 2025
 ** 42sh
 ** File description:
-** tests_ast_build
+** Tests unitaires pour read_command et build_ast_struct
 */
 
 #include <criterion/criterion.h>
 #include <criterion/redirect.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
 #include "shell.h"
 
-void cr_mock_stdin(char *input)
-{
+// Fonction pour mocker stdin
+void cr_mock_stdin(char *input) {
     FILE *mock_input = fmemopen(input, strlen(input), "r");
     if (mock_input == NULL) {
         perror("fmemopen");
@@ -22,64 +23,247 @@ void cr_mock_stdin(char *input)
     stdin = mock_input;
 }
 
-
-Test(read_command, simple_input)
-{
+// Tests pour read_command
+Test(read_command, simple_input) {
     const char *input = "ls -la\n";
+    shell_t shell = {0};
+    bool had_error = false;
     char *result;
 
     cr_mock_stdin((char *)input);
 
-    result = read_command();
+    result = read_command(&shell, &had_error);
 
     cr_assert_not_null(result);
-    cr_assert_str_eq(result, "ls -la\n");
+    cr_assert_str_eq(result, "ls -la");
+    cr_assert_eq(had_error, false);
 
     free(result);
 }
 
-Test(read_command, eof_input)
-{
+Test(read_command, eof_input) {
     FILE *null_input = fopen("/dev/null", "r");
     cr_assert_not_null(null_input);
     FILE *old_stdin = stdin;
+    shell_t shell = {0};
+    bool had_error = false;
+
     stdin = null_input;
 
-    char *result = read_command();
+    char *result = read_command(&shell, &had_error);
 
     cr_assert_null(result);
+    cr_assert_eq(had_error, false);
 
     stdin = old_stdin;
     fclose(null_input);
 }
 
-
-Test(build_ast_struct, simple_input)
-{
+Test(read_command, with_history) {
     const char *input = "ls -la\n";
-    ast_node_t *ast;
+    shell_t shell = {0};
+    bool had_error = false;
+    char *result;
 
-    ast = built_ast_struct((char *)input);
+    // Initialiser l'historique
+    shell.history = init_history();
+    cr_assert_not_null(shell.history);
 
-    cr_assert_not_null(ast);
+    cr_mock_stdin((char *)input);
+
+    result = read_command(&shell, &had_error);
+
+    cr_assert_not_null(result);
+    cr_assert_str_eq(result, "ls -la");
+    cr_assert_eq(had_error, false);
+
+    // Vérifier que l'historique a été mis à jour
+    cr_assert_eq(shell.history->count, 1);
+    cr_assert_str_eq(shell.history->entries[0].command, "ls -la");
+
+    free(result);
+    // Libérer la mémoire
+    free(shell.history->entries[0].command);
+    free(shell.history->entries[0].timestamp);
+    free(shell.history->entries);
+    free(shell.history);
 }
 
-Test(build_ast_struct, empty_input)
-{
-    const char *input = "";
+Test(read_command, history_expansion_bang_bang) {
+    shell_t shell = {0};
+    bool had_error = false;
+    char *result;
+
+    // Initialiser l'historique avec une commande
+    shell.history = init_history();
+    cr_assert_not_null(shell.history);
+    history_add(shell.history, "echo hello");
+
+    // Simuler une entrée avec expansion d'historique !!
+    cr_mock_stdin("!!\n");
+
+    result = read_command(&shell, &had_error);
+
+    cr_assert_not_null(result);
+    cr_assert_str_eq(result, "echo hello");
+    cr_assert_eq(had_error, false);
+
+    free(result);
+    // Libérer la mémoire
+    free(shell.history->entries[0].command);
+    free(shell.history->entries[0].timestamp);
+    free(shell.history->entries);
+    free(shell.history);
+}
+
+Test(read_command, history_expansion_by_number) {
+    shell_t shell = {0};
+    bool had_error = false;
+    char *result;
+
+    // Initialiser l'historique avec plusieurs commandes
+    shell.history = init_history();
+    cr_assert_not_null(shell.history);
+    history_add(shell.history, "ls");
+    history_add(shell.history, "cd /tmp");
+    history_add(shell.history, "echo test");
+
+    // Simuler une entrée avec expansion d'historique !2
+    cr_mock_stdin("!2\n");
+
+    result = read_command(&shell, &had_error);
+
+    cr_assert_not_null(result);
+    cr_assert_str_eq(result, "cd /tmp");
+    cr_assert_eq(had_error, false);
+
+    free(result);
+    // Libérer la mémoire
+    for (int i = 0; i < shell.history->count; i++) {
+        free(shell.history->entries[i].command);
+        free(shell.history->entries[i].timestamp);
+    }
+    free(shell.history->entries);
+    free(shell.history);
+}
+
+Test(read_command, history_expansion_by_prefix) {
+    shell_t shell = {0};
+    bool had_error = false;
+    char *result;
+
+    // Initialiser l'historique avec plusieurs commandes
+    shell.history = init_history();
+    cr_assert_not_null(shell.history);
+    history_add(shell.history, "ls -la");
+    history_add(shell.history, "echo test");
+    history_add(shell.history, "cd /usr/bin");
+
+    // Simuler une entrée avec expansion d'historique !ec
+    cr_mock_stdin("!ec\n");
+
+    result = read_command(&shell, &had_error);
+
+    cr_assert_not_null(result);
+    cr_assert_str_eq(result, "echo test");
+    cr_assert_eq(had_error, false);
+
+    free(result);
+    // Libérer la mémoire
+    for (int i = 0; i < shell.history->count; i++) {
+        free(shell.history->entries[i].command);
+        free(shell.history->entries[i].timestamp);
+    }
+    free(shell.history->entries);
+    free(shell.history);
+}
+
+Test(read_command, history_expansion_error) {
+    shell_t shell = {0};
+    bool had_error = false;
+    char *result;
+
+    // Initialiser l'historique
+    shell.history = init_history();
+    cr_assert_not_null(shell.history);
+
+    // Simuler une entrée avec expansion d'historique invalide
+    cr_mock_stdin("!nonexistent\n");
+
+    result = read_command(&shell, &had_error);
+
+    cr_assert_null(result);
+    cr_assert_eq(had_error, true);
+
+    // Libérer la mémoire
+    free(shell.history->entries);
+    free(shell.history);
+}
+
+// Tests pour built_ast_struct
+Test(build_ast_struct, simple_input) {
+    char *input = strdup("ls -la");
+    shell_t shell = {0};
     ast_node_t *ast;
 
-    ast = built_ast_struct((char *)input);
+    ast = built_ast_struct(input, &shell);
+
+    cr_assert_not_null(ast);
+
+    free(input);
+    // Note: il faudrait libérer l'AST ici, mais la fonction n'est pas fournie
+}
+
+Test(build_ast_struct, empty_input) {
+    char *input = strdup("");
+    shell_t shell = {0};
+    ast_node_t *ast;
+
+    ast = built_ast_struct(input, &shell);
+
+    cr_assert_null(ast);
+
+    free(input);
+}
+
+Test(build_ast_struct, null_input) {
+    shell_t shell = {0};
+    ast_node_t *ast;
+
+    ast = built_ast_struct(NULL, &shell);
 
     cr_assert_null(ast);
 }
 
-Test(build_ast_struct, invalid_input)
-{
-    const char *input = "ls -la | grep test\n";
+Test(build_ast_struct, complex_input) {
+    char *input = strdup("ls -la | grep test");
+    shell_t shell = {0};
     ast_node_t *ast;
 
-    ast = built_ast_struct((char *)input);
+    ast = built_ast_struct(input, &shell);
 
     cr_assert_not_null(ast);
+
+    free(input);
+    // Note: il faudrait libérer l'AST ici, mais la fonction n'est pas fournie
+}
+
+Test(build_ast_struct, error_handling) {
+    char *input = strdup("ls -la | grep test");
+    shell_t shell = {0};
+    ast_node_t *ast;
+
+    // Simuler une erreur dans le traitement de l'AST
+    // Note: comme nous n'avons pas accès à l'implémentation complète,
+    // ce test pourrait ne pas fonctionner comme prévu.
+    // Ajustez selon votre implémentation réelle.
+
+    ast = built_ast_struct(input, &shell);
+
+    // Si le test échoue, vérifiez que shell_info->exit_code a été mis à jour
+    if (!ast) {
+        cr_assert_eq(shell.exit_code, 1);
+    }
+
+    free(input);
 }

--- a/tests/parser/tests_ast_build.c
+++ b/tests/parser/tests_ast_build.c
@@ -1,0 +1,85 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** tests_ast_build
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "shell.h"
+
+void cr_mock_stdin(char *input)
+{
+    FILE *mock_input = fmemopen(input, strlen(input), "r");
+    if (mock_input == NULL) {
+        perror("fmemopen");
+        exit(EXIT_FAILURE);
+    }
+    stdin = mock_input;
+}
+
+
+Test(read_command, simple_input)
+{
+    const char *input = "ls -la\n";
+    char *result;
+
+    cr_mock_stdin((char *)input);
+
+    result = read_command();
+
+    cr_assert_not_null(result);
+    cr_assert_str_eq(result, "ls -la\n");
+
+    free(result);
+}
+
+Test(read_command, eof_input)
+{
+    FILE *null_input = fopen("/dev/null", "r");
+    cr_assert_not_null(null_input);
+    FILE *old_stdin = stdin;
+    stdin = null_input;
+
+    char *result = read_command();
+
+    cr_assert_null(result);
+
+    stdin = old_stdin;
+    fclose(null_input);
+}
+
+
+Test(build_ast_struct, simple_input)
+{
+    const char *input = "ls -la\n";
+    ast_node_t *ast;
+
+    ast = built_ast_struct((char *)input);
+
+    cr_assert_not_null(ast);
+}
+
+Test(build_ast_struct, empty_input)
+{
+    const char *input = "";
+    ast_node_t *ast;
+
+    ast = built_ast_struct((char *)input);
+
+    cr_assert_null(ast);
+}
+
+Test(build_ast_struct, invalid_input)
+{
+    const char *input = "ls -la | grep test\n";
+    ast_node_t *ast;
+
+    ast = built_ast_struct((char *)input);
+
+    cr_assert_not_null(ast);
+}

--- a/tests/parser/tests_ast_build.c
+++ b/tests/parser/tests_ast_build.c
@@ -23,7 +23,6 @@ void cr_mock_stdin(char *input) {
     stdin = mock_input;
 }
 
-// Tests pour read_command
 Test(read_command, simple_input) {
     const char *input = "ls -la\n";
     shell_t shell = {0};
@@ -65,7 +64,6 @@ Test(read_command, with_history) {
     bool had_error = false;
     char *result;
 
-    // Initialiser l'historique
     shell.history = init_history();
     cr_assert_not_null(shell.history);
 
@@ -77,12 +75,10 @@ Test(read_command, with_history) {
     cr_assert_str_eq(result, "ls -la");
     cr_assert_eq(had_error, false);
 
-    // Vérifier que l'historique a été mis à jour
     cr_assert_eq(shell.history->count, 1);
     cr_assert_str_eq(shell.history->entries[0].command, "ls -la");
 
     free(result);
-    // Libérer la mémoire
     free(shell.history->entries[0].command);
     free(shell.history->entries[0].timestamp);
     free(shell.history->entries);
@@ -94,12 +90,10 @@ Test(read_command, history_expansion_bang_bang) {
     bool had_error = false;
     char *result;
 
-    // Initialiser l'historique avec une commande
     shell.history = init_history();
     cr_assert_not_null(shell.history);
     history_add(shell.history, "echo hello");
 
-    // Simuler une entrée avec expansion d'historique !!
     cr_mock_stdin("!!\n");
 
     result = read_command(&shell, &had_error);
@@ -121,14 +115,12 @@ Test(read_command, history_expansion_by_number) {
     bool had_error = false;
     char *result;
 
-    // Initialiser l'historique avec plusieurs commandes
     shell.history = init_history();
     cr_assert_not_null(shell.history);
     history_add(shell.history, "ls");
     history_add(shell.history, "cd /tmp");
     history_add(shell.history, "echo test");
 
-    // Simuler une entrée avec expansion d'historique !2
     cr_mock_stdin("!2\n");
 
     result = read_command(&shell, &had_error);
@@ -138,7 +130,6 @@ Test(read_command, history_expansion_by_number) {
     cr_assert_eq(had_error, false);
 
     free(result);
-    // Libérer la mémoire
     for (int i = 0; i < shell.history->count; i++) {
         free(shell.history->entries[i].command);
         free(shell.history->entries[i].timestamp);
@@ -152,14 +143,12 @@ Test(read_command, history_expansion_by_prefix) {
     bool had_error = false;
     char *result;
 
-    // Initialiser l'historique avec plusieurs commandes
     shell.history = init_history();
     cr_assert_not_null(shell.history);
     history_add(shell.history, "ls -la");
     history_add(shell.history, "echo test");
     history_add(shell.history, "cd /usr/bin");
 
-    // Simuler une entrée avec expansion d'historique !ec
     cr_mock_stdin("!ec\n");
 
     result = read_command(&shell, &had_error);
@@ -169,7 +158,6 @@ Test(read_command, history_expansion_by_prefix) {
     cr_assert_eq(had_error, false);
 
     free(result);
-    // Libérer la mémoire
     for (int i = 0; i < shell.history->count; i++) {
         free(shell.history->entries[i].command);
         free(shell.history->entries[i].timestamp);
@@ -183,11 +171,9 @@ Test(read_command, history_expansion_error) {
     bool had_error = false;
     char *result;
 
-    // Initialiser l'historique
     shell.history = init_history();
     cr_assert_not_null(shell.history);
 
-    // Simuler une entrée avec expansion d'historique invalide
     cr_mock_stdin("!nonexistent\n");
 
     result = read_command(&shell, &had_error);
@@ -195,12 +181,10 @@ Test(read_command, history_expansion_error) {
     cr_assert_null(result);
     cr_assert_eq(had_error, true);
 
-    // Libérer la mémoire
     free(shell.history->entries);
     free(shell.history);
 }
 
-// Tests pour built_ast_struct
 Test(build_ast_struct, simple_input) {
     char *input = strdup("ls -la");
     shell_t shell = {0};
@@ -211,7 +195,6 @@ Test(build_ast_struct, simple_input) {
     cr_assert_not_null(ast);
 
     free(input);
-    // Note: il faudrait libérer l'AST ici, mais la fonction n'est pas fournie
 }
 
 Test(build_ast_struct, empty_input) {
@@ -245,7 +228,6 @@ Test(build_ast_struct, complex_input) {
     cr_assert_not_null(ast);
 
     free(input);
-    // Note: il faudrait libérer l'AST ici, mais la fonction n'est pas fournie
 }
 
 Test(build_ast_struct, error_handling) {
@@ -253,14 +235,8 @@ Test(build_ast_struct, error_handling) {
     shell_t shell = {0};
     ast_node_t *ast;
 
-    // Simuler une erreur dans le traitement de l'AST
-    // Note: comme nous n'avons pas accès à l'implémentation complète,
-    // ce test pourrait ne pas fonctionner comme prévu.
-    // Ajustez selon votre implémentation réelle.
-
     ast = built_ast_struct(input, &shell);
 
-    // Si le test échoue, vérifiez que shell_info->exit_code a été mis à jour
     if (!ast) {
         cr_assert_eq(shell.exit_code, 1);
     }

--- a/tests/utils/tests_strcat.c
+++ b/tests/utils/tests_strcat.c
@@ -1,0 +1,51 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** tests_strcat
+*/
+
+#include <criterion/criterion.h>
+#include <string.h>
+#include <stdlib.h>
+
+char *my_strcat(char *dest, char *str);
+
+Test(my_strcat, basic_concatenation)
+{
+    char *result = my_strcat("Hello", " World");
+
+    cr_assert_not_null(result);
+    cr_assert_str_eq(result, "Hello World");
+    free(result);
+}
+
+Test(my_strcat, concatenate_with_empty_string)
+{
+    char *result1 = my_strcat("Hello", "");
+    cr_assert_not_null(result1);
+    cr_assert_str_eq(result1, "Hello");
+    free(result1);
+
+    char *result2 = my_strcat("", "World");
+    cr_assert_not_null(result2);
+    cr_assert_str_eq(result2, "World");
+    free(result2);
+}
+
+Test(my_strcat, concatenate_two_empty_strings)
+{
+    char *result = my_strcat("", "");
+
+    cr_assert_not_null(result);
+    cr_assert_str_eq(result, "");
+    free(result);
+}
+
+Test(my_strcat, returns_new_allocated_string)
+{
+    char *res = my_strcat("foo", "bar");
+    cr_assert_neq(res, "foobar");
+    cr_assert_str_eq(res, "foobar");
+    free(res);
+}

--- a/tests_src.list
+++ b/tests_src.list
@@ -20,3 +20,4 @@ tests/env/test_env_unset.c
 tests/env/test_local_get.c
 tests/env/test_local_set.c
 tests/env/test_local_unset.c
+tests/parser/tests_ast_build.c

--- a/tests_src.list
+++ b/tests_src.list
@@ -21,3 +21,4 @@ tests/env/test_local_get.c
 tests/env/test_local_set.c
 tests/env/test_local_unset.c
 tests/parser/tests_ast_build.c
+tests/utils/tests_strcat.c


### PR DESCRIPTION
This pull request introduces unit tests for two key functionalities (`read_command` and `build_ast_struct`) and a utility function (`my_strcat`). It also updates the test suite configuration to include these new test files. Below is a summary of the most important changes:

### Added Unit Tests for Command Parsing and AST Building

* [`tests/parser/tests_ast_build.c`](diffhunk://#diff-239e0d8b4358506e6e0730b42e592b0a10e0924b3474a7789d04da793a789455R1-R85): Added tests for `read_command` to validate handling of simple input and EOF scenarios. Tests for `build_ast_struct` were also added to ensure correct AST creation for valid, empty, and invalid inputs.

### Added Unit Tests for String Concatenation Utility

* [`tests/utils/tests_strcat.c`](diffhunk://#diff-8795912cc487a036e5983ee490cd61467ff3509ca4657b533f2e661d53cb5fe6R1-R51): Introduced tests for `my_strcat` to verify basic concatenation, handling of empty strings, and memory allocation for the resulting string.

### Updated Test Suite Configuration

* [`tests_src.list`](diffhunk://#diff-24c181b4d27c885f758b3e8304586844909aa283f1fba3d641782095d0810244R23-R24): Included the new test files `tests/parser/tests_ast_build.c` and `tests/utils/tests_strcat.c` in the test suite configuration.