### PR TITLE
feat(globbings): implement file globbing functionality

### DIFF
--- a/include/globbings.h
+++ b/include/globbings.h
@@ -12,7 +12,7 @@
 typedef struct recursive_data {
     int *count;
     int deepth;
-    int max_deepth;
+    int max_depth;
     char **files;
 } recursive_data_t;
 

--- a/include/globbings.h
+++ b/include/globbings.h
@@ -13,6 +13,7 @@ struct recursive_data {
     int *count;
     int deepth;
     int max_deepth;
+    char **files;
 } typedef recursive_data_t;
 
 /*utility function to get a list of all the file*/

--- a/include/globbings.h
+++ b/include/globbings.h
@@ -9,7 +9,16 @@
     #define INCLUDED_GLOBBINGS_H
     #include "ast.h"
 
+struct recursive_data {
+    int *count;
+    int deepth;
+    int max_deepth;
+} typedef recursive_data_t;
+
+/*utility function to get a list of all the file*/
 char **get_files(const char *path, int *count);
+//void get_all_files_recursive(char *base_path, char ***files, recursive_data_t *data);
+
 int globbings(ast_node_t *node);
 
 #endif

--- a/include/globbings.h
+++ b/include/globbings.h
@@ -19,7 +19,7 @@ struct recursive_data {
 /*utility function to get a list of all the file*/
 char **get_files(const char *path, int *count);
 char **get_directory(char *path, int *count);
-void get_all_files_recursive(const char *base_path, char ***files, int *count, int deepth, int max_deepth, recursive_data_t *data);
+void get_all_files_recursive(const char *base_path, int deepth, recursive_data_t *data);
 //void get_all_files_recursive(char *base_path, char ***files, recursive_data_t *data);
 
 int globbings(ast_node_t *node);

--- a/include/globbings.h
+++ b/include/globbings.h
@@ -19,6 +19,7 @@ struct recursive_data {
 /*utility function to get a list of all the file*/
 char **get_files(const char *path, int *count);
 char **get_directory(char *path, int *count);
+void get_all_files_recursive(const char *base_path, char ***files, int *count, int deepth, int max_deepth, recursive_data_t *data);
 //void get_all_files_recursive(char *base_path, char ***files, recursive_data_t *data);
 
 int globbings(ast_node_t *node);

--- a/include/globbings.h
+++ b/include/globbings.h
@@ -18,6 +18,7 @@ struct recursive_data {
 
 /*utility function to get a list of all the file*/
 char **get_files(const char *path, int *count);
+char **get_directory(char *path, int *count);
 //void get_all_files_recursive(char *base_path, char ***files, recursive_data_t *data);
 
 int globbings(ast_node_t *node);

--- a/include/globbings.h
+++ b/include/globbings.h
@@ -1,0 +1,15 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** globbings
+*/
+
+#ifndef INCLUDED_GLOBBINGS_H
+    #define INCLUDED_GLOBBINGS_H
+    #include "ast.h"
+
+char **get_files(const char *path, int *count);
+int globbings(ast_node_t *node);
+
+#endif

--- a/include/globbings.h
+++ b/include/globbings.h
@@ -9,19 +9,22 @@
     #define INCLUDED_GLOBBINGS_H
     #include "ast.h"
 
-struct recursive_data {
+typedef struct recursive_data {
     int *count;
     int deepth;
     int max_deepth;
     char **files;
-} typedef recursive_data_t;
+} recursive_data_t;
 
-/*utility function to get a list of all the file*/
 char **get_files(const char *path, int *count);
 char **get_directory(char *path, int *count);
-void get_all_files_recursive(const char *base_path, int deepth, recursive_data_t *data);
-//void get_all_files_recursive(char *base_path, char ***files, recursive_data_t *data);
+void get_all_files_recursive(const char *base_path, int deepth,
+    recursive_data_t *data);
 
-int globbings(ast_node_t *node);
+void globbings(ast_node_t *node);
+
+void free_selected_files(char **selected_file);
+void free_files(char **files, int count);
+void free_var(char **selected_file, char **files, char *pattern, int count);
 
 #endif

--- a/src.list
+++ b/src.list
@@ -35,3 +35,4 @@ src/utils/strcat.c
 src/command_execution/get_redirect_handler.c
 src/globbings/get_file.c
 src/globbings/globbings.c
+src/globbings/get_directory.c

--- a/src.list
+++ b/src.list
@@ -33,3 +33,5 @@ src/env/local_unset.c
 src/command_execution/get_command_path.c
 src/utils/strcat.c
 src/command_execution/get_redirect_handler.c
+src/globbings/get_file.c
+src/globbings/globbings.c

--- a/src/command_execution/execute_command.c
+++ b/src/command_execution/execute_command.c
@@ -17,6 +17,7 @@
 #include <sys/stat.h>
 #include <signal.h>
 #include <unistd.h>
+#include "globbings.h"
 
 static void child_process(
     char *full_path, ast_node_t *node, struct shell_s *shell_var)
@@ -69,6 +70,7 @@ int execute_command(ast_node_t *node, struct shell_s *shell_var)
         free(full_path);
         return result;
     }
+    globbings(node);
     result = execute_external_command(full_path, node, shell_var);
     free(full_path);
     return result;

--- a/src/globbings/get_directory.c
+++ b/src/globbings/get_directory.c
@@ -10,38 +10,68 @@
 #include <string.h>
 #include <stdio.h>
 
+static char *join_path(const char *dir, const char *file)
+{
+    size_t len = strlen(dir) + strlen(file) + 2;
+    char *full = malloc(len);
+
+    if (!full)
+        return NULL;
+    if (dir[strlen(dir) - 1] == '/')
+        snprintf(full, len, "%s%s", dir, file);
+    else
+        snprintf(full, len, "%s/%s", dir, file);
+    return full;
+}
+
+static void add_to_directory(char ***directory, int *count_files, const char *new_path, const char *entry_name)
+{
+    char *full_path = join_path(new_path, entry_name);
+
+    if (!full_path)
+        return;
+    *directory = realloc(*directory, sizeof(char *) * (*count_files + 1));
+    if (!*directory) {
+        free(full_path);
+        return;
+    }
+    (*directory)[*count_files] = strdup(full_path);
+    (*count_files)++;
+    free(full_path);
+}
+
+static void process_directory_entries(DIR *dir, char ***directory, int *count_files, const char *new_path)
+{
+    struct dirent *entry;
+
+    while (entry != NULL) {
+        entry = readdir(dir);
+        if (entry == NULL)
+            break;
+        if (entry->d_name[0] == '.')
+            continue;
+        add_to_directory(directory, count_files, new_path, entry->d_name);
+    }
+}
+
 char **get_directory(char *path, int *count)
 {
     char *new_path = strtok(path, "*");
-    if (new_path == NULL)
-        new_path = strdup(".");
-    printf("new_path: %s\n", new_path);
-    DIR *dir = opendir(new_path);
-    struct dirent *entry;
+    DIR *dir;
     char **directory = NULL;
     int count_files = 0;
 
+    if (new_path == NULL)
+        new_path = strdup(".");
+    dir = opendir(new_path);
     if (!dir)
         return NULL;
-    directory = malloc(sizeof(char *) * 1);
+    directory = malloc(sizeof(char *));
     if (!directory) {
         closedir(dir);
         return NULL;
     }
-    
-    while ((entry = readdir(dir)) != NULL) {
-        printf("entry: %s\n", entry->d_name);
-        if (entry->d_name[0] == '.')
-            continue;
-        directory = realloc(directory, sizeof(char *) * (count_files + 1));
-        if (!directory) {
-            closedir(dir);
-            return NULL;
-        }
-        directory[count_files] = strdup(entry->d_name);
-        count_files++;
-    }
-    
+    process_directory_entries(dir, &directory, &count_files, new_path);
     closedir(dir);
     *count = count_files;
     return directory;

--- a/src/globbings/get_directory.c
+++ b/src/globbings/get_directory.c
@@ -24,7 +24,8 @@ static char *join_path(const char *dir, const char *file)
     return full;
 }
 
-static void add_to_directory(char ***directory, int *count_files, const char *new_path, const char *entry_name)
+static void add_to_directory(char ***directory, int *count_files,
+    const char *new_path, const char *entry_name)
 {
     char *full_path = join_path(new_path, entry_name);
 
@@ -40,11 +41,12 @@ static void add_to_directory(char ***directory, int *count_files, const char *ne
     free(full_path);
 }
 
-static void process_directory_entries(DIR *dir, char ***directory, int *count_files, const char *new_path)
+static void process_directory_entries(DIR *dir, char ***directory,
+    int *count_files, const char *new_path)
 {
     struct dirent *entry;
 
-    while (entry != NULL) {
+    while (1) {
         entry = readdir(dir);
         if (entry == NULL)
             break;

--- a/src/globbings/get_directory.c
+++ b/src/globbings/get_directory.c
@@ -1,0 +1,48 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** get_directory
+*/
+
+#include "globbings.h"
+#include <dirent.h>
+#include <string.h>
+#include <stdio.h>
+
+char **get_directory(char *path, int *count)
+{
+    char *new_path = strtok(path, "*");
+    if (new_path == NULL)
+        new_path = strdup(".");
+    printf("new_path: %s\n", new_path);
+    DIR *dir = opendir(new_path);
+    struct dirent *entry;
+    char **directory = NULL;
+    int count_files = 0;
+
+    if (!dir)
+        return NULL;
+    directory = malloc(sizeof(char *) * 1);
+    if (!directory) {
+        closedir(dir);
+        return NULL;
+    }
+    
+    while ((entry = readdir(dir)) != NULL) {
+        printf("entry: %s\n", entry->d_name);
+        if (entry->d_name[0] == '.')
+            continue;
+        directory = realloc(directory, sizeof(char *) * (count_files + 1));
+        if (!directory) {
+            closedir(dir);
+            return NULL;
+        }
+        directory[count_files] = strdup(entry->d_name);
+        count_files++;
+    }
+    
+    closedir(dir);
+    *count = count_files;
+    return directory;
+}

--- a/src/globbings/get_file.c
+++ b/src/globbings/get_file.c
@@ -107,7 +107,7 @@ void get_all_files_recursive(const char *base_path, int deepth,
         new_path = ".";
     dir = opendir(new_path);
     deepth += 1;
-    if (!dir || deepth >= data->max_deepth) {
+    if (!dir || deepth >= data->max_depth) {
         if (dir)
             closedir(dir);
         free(base_path_copy);
@@ -128,7 +128,7 @@ char **get_files(const char *start_path, int *count)
         return NULL;
     data->count = count;
     data->deepth = 0;
-    data->max_deepth = get_max_depth(start_path);
+    data->max_depth = get_max_depth(start_path);
     get_all_files_recursive(start_path, 0, data);
     return data->files;
 }

--- a/src/globbings/get_file.c
+++ b/src/globbings/get_file.c
@@ -44,10 +44,14 @@ static int max_deepth(const char *path) {
 }
 
 static void get_all_files_recursive(const char *base_path, char ***files, int *count, int deepth, int max_deepth, recursive_data_t *data) {
-    DIR *dir = opendir(strtok(base_path, "*"));
+    char *new_path = strtok(base_path, "*");
+    if (new_path == NULL)
+        new_path = strdup(".");
+    DIR *dir = opendir(new_path);
     struct dirent *entry;
     char *full_path = NULL;
 
+    
     deepth += 1;
     if (!dir)
         return;
@@ -56,6 +60,9 @@ static void get_all_files_recursive(const char *base_path, char ***files, int *c
         return;
     }
     while ((entry = readdir(dir)) != NULL) {
+        printf("file entry: %s\n", entry->d_name);
+        if (entry->d_name[0] == '.')
+            continue;
         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
             continue;
         full_path = join_path(base_path, entry->d_name);
@@ -84,13 +91,9 @@ char **get_files(const char *start_path, int *count) {
     if (start_path == NULL || start_path[0] == '\0')
         return NULL;
     data->count = count;
-    printf("test\n");
     data->deepth = 0;
     data->max_deepth = max_deepth(start_path);
+    printf("file max deepth: %i\n", data->max_deepth);
     get_all_files_recursive(start_path, &files, count, 0, max_deepth(start_path), data);
-    printf("count = %i\n", (*count));
-    for (int i = 0; files[i]; i++) {
-        printf("%s\n", files[i]);
-    }
     return files;
 }

--- a/src/globbings/get_file.c
+++ b/src/globbings/get_file.c
@@ -1,0 +1,68 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** get_file
+*/
+
+#include "ast.h"
+#include <dirent.h>
+#include <fnmatch.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+
+int is_directory(const char *path) {
+    struct stat st;
+    return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
+char *join_path(const char *dir, const char *file) {
+    size_t len = strlen(dir) + strlen(file) + 2;
+    char *full = malloc(len);
+    if (!full)
+        return NULL;
+    snprintf(full, len, "%s/%s", dir, file);
+    return full;
+}
+
+void get_all_files_recursive(const char *base_path, char ***files, int *count) {
+    DIR *dir = opendir(base_path);
+    struct dirent *entry;
+    char *full_path = NULL;
+
+    if (!dir)
+        return;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            continue;
+        full_path = join_path(base_path, entry->d_name);
+        if (!full_path)
+            continue;
+        if (is_directory(full_path)) {
+            get_all_files_recursive(full_path, files, count);
+        } else {
+            *files = realloc(*files, sizeof(char *) * (*count + 1));
+            if (!*files)
+                return;
+            (*files)[*count] = full_path;
+            (*count)++;
+            continue;
+        }
+        free(full_path);
+    }
+    closedir(dir);
+}
+
+char **get_files(const char *start_path, int *count) {
+    char **files = NULL;
+
+    *count = 0;
+    get_all_files_recursive(start_path, &files, count);
+    printf("%i\n", (*count));
+    for (int i = 0; files[i]; i++) {
+        printf("%s\n", files[i]);
+    }
+    return files;
+}

--- a/src/globbings/get_file.c
+++ b/src/globbings/get_file.c
@@ -14,14 +14,18 @@
 #include <sys/stat.h>
 #include "globbings.h"
 
-static int is_directory(const char *path) {
+static int is_directory(const char *path)
+{
     struct stat st;
+
     return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
 }
 
-static char *join_path(const char *dir, const char *file) {
+static char *join_path(const char *dir, const char *file)
+{
     size_t len = strlen(dir) + strlen(file) + 2;
     char *full = malloc(len);
+
     if (!full)
         return NULL;
     if (dir[strlen(dir) - 1] == '/')
@@ -31,7 +35,8 @@ static char *join_path(const char *dir, const char *file) {
     return full;
 }
 
-static int max_deepth(const char *path) {
+static int max_deepth(const char *path)
+{
     int depth = 1;
     const char *p = path;
 
@@ -43,49 +48,57 @@ static int max_deepth(const char *path) {
     return depth;
 }
 
-static void get_all_files_recursive(const char *base_path, char ***files, int *count, int deepth, int max_deepth, recursive_data_t *data) {
+static void process_directory_entry(const char *base_path, struct dirent *entry, char ***files, recursive_data_t *data, int deepth)
+{
+    char *full_path = join_path(base_path, entry->d_name);
+
+    if (!full_path)
+        return;
+    if (is_directory(full_path)) {
+        get_all_files_recursive(full_path, files, data->count, deepth, data->max_deepth, data);
+    } else {
+        *files = realloc(*files, sizeof(char *) * (*data->count + 1));
+        if (!*files) {
+            free(full_path);
+            return;
+        }
+        (*files)[*data->count] = full_path;
+        (*data->count)++;
+    }
+}
+
+void get_all_files_recursive(const char *base_path, char ***files, int *count, int deepth, int max_deepth, recursive_data_t *data)
+{
     char *new_path = strtok(base_path, "*");
+    DIR *dir;
+    struct dirent *entry;
+
     if (new_path == NULL)
         new_path = strdup(".");
-    DIR *dir = opendir(new_path);
-    struct dirent *entry;
-    char *full_path = NULL;
-
-    
+    dir = opendir(new_path);
     deepth += 1;
-    if (!dir)
-        return;
-    if (deepth >= data->max_deepth) {
-        closedir(dir);
+    if (!dir || deepth >= data->max_deepth) {
+        if (dir)
+            closedir(dir);
         return;
     }
-    while ((entry = readdir(dir)) != NULL) {
-        printf("file entry: %s\n", entry->d_name);
-        if (entry->d_name[0] == '.')
+    while (entry != NULL) {
+        entry = readdir(dir);
+        if (entry == NULL)
+            break;
+        if (entry->d_name[0] == '.' || strcmp(entry->d_name, ".") == 0 ||
+        strcmp(entry->d_name, "..") == 0)
             continue;
-        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
-            continue;
-        full_path = join_path(base_path, entry->d_name);
-        if (!full_path)
-            continue;
-        if (is_directory(full_path)) {
-            get_all_files_recursive(full_path, files, count, deepth, max_deepth, data);
-        } else {
-            *files = realloc(*files, sizeof(char *) * (*data->count + 1));
-            if (!*files)
-                return;
-            (*files)[*data->count] = full_path;
-            (*data->count)++;
-            continue;
-        }
-        free(full_path);
+        process_directory_entry(base_path, entry, files, data, deepth);
     }
     closedir(dir);
 }
 
-char **get_files(const char *start_path, int *count) {
+char **get_files(const char *start_path, int *count)
+{
     char **files = NULL;
     recursive_data_t *data = malloc(sizeof(recursive_data_t));
+
     if (!data)
         return NULL;
     if (start_path == NULL || start_path[0] == '\0')

--- a/src/globbings/get_file.c
+++ b/src/globbings/get_file.c
@@ -43,7 +43,7 @@ static int max_deepth(const char *path) {
     return depth;
 }
 
-static void get_all_files_recursive(const char *base_path, char ***files, int *count, int deepth, int max_deepth) {
+static void get_all_files_recursive(const char *base_path, char ***files, int *count, int deepth, int max_deepth, recursive_data_t *data) {
     DIR *dir = opendir(strtok(base_path, "*"));
     struct dirent *entry;
     char *full_path = NULL;
@@ -51,7 +51,7 @@ static void get_all_files_recursive(const char *base_path, char ***files, int *c
     deepth += 1;
     if (!dir)
         return;
-    if (deepth >= max_deepth) {
+    if (deepth >= data->max_deepth) {
         closedir(dir);
         return;
     }
@@ -62,13 +62,13 @@ static void get_all_files_recursive(const char *base_path, char ***files, int *c
         if (!full_path)
             continue;
         if (is_directory(full_path)) {
-            get_all_files_recursive(full_path, files, count, deepth, max_deepth);
+            get_all_files_recursive(full_path, files, count, deepth, max_deepth, data);
         } else {
-            *files = realloc(*files, sizeof(char *) * (*count + 1));
+            *files = realloc(*files, sizeof(char *) * (*data->count + 1));
             if (!*files)
                 return;
-            (*files)[*count] = full_path;
-            (*count)++;
+            (*files)[*data->count] = full_path;
+            (*data->count)++;
             continue;
         }
         free(full_path);
@@ -84,9 +84,10 @@ char **get_files(const char *start_path, int *count) {
     if (start_path == NULL || start_path[0] == '\0')
         return NULL;
     data->count = count;
+    printf("test\n");
     data->deepth = 0;
     data->max_deepth = max_deepth(start_path);
-    get_all_files_recursive(start_path, &files, count, 0, max_deepth(start_path));
+    get_all_files_recursive(start_path, &files, count, 0, max_deepth(start_path), data);
     printf("count = %i\n", (*count));
     for (int i = 0; files[i]; i++) {
         printf("%s\n", files[i]);

--- a/src/globbings/get_file.c
+++ b/src/globbings/get_file.c
@@ -42,7 +42,7 @@ static char *join_path(const char *dir, const char *file)
     return full;
 }
 
-static int get_max_deepth(const char *path)
+static int get_max_depth(const char *path)
 {
     int depth = 1;
     const char *p = path;
@@ -128,7 +128,7 @@ char **get_files(const char *start_path, int *count)
         return NULL;
     data->count = count;
     data->deepth = 0;
-    data->max_deepth = get_max_deepth(start_path);
+    data->max_deepth = get_max_depth(start_path);
     get_all_files_recursive(start_path, 0, data);
     return data->files;
 }

--- a/src/globbings/globbings.c
+++ b/src/globbings/globbings.c
@@ -12,6 +12,12 @@
 #include <ftw.h>
 #include <string.h>
 
+static int is_globbing_pattern(const char *str)
+{
+    return (strchr(str, '*') || strchr(str, '?') ||
+            strchr(str, '[') || strchr(str, '{'));
+}
+
 static int is_globbings_pattern(char *pattern)
 {
     if (pattern == NULL)
@@ -29,7 +35,8 @@ static char **get_selected_files(char **files, char *pattern, int count_files)
     for (int i = 0; i < count_files; i++) {
         if (fnmatch(pattern, files[i], 0) == 0) {
             count++;
-            selected_files = realloc(selected_files, sizeof(char *) * (count + 1));
+            selected_files = realloc(selected_files, sizeof(char *) *
+            (count + 1));
             selected_files[count - 1] = strdup(files[i]);
         }
     }
@@ -40,15 +47,14 @@ static char **get_selected_files(char **files, char *pattern, int count_files)
 
 static char *get_pattern(char *src)
 {
-    if (src == NULL)
-        return NULL;
-    char *pattern = strdup(src);
+    char *pattern;
     char *new_pattern;
 
+    if (src == NULL)
+        return NULL;
+    pattern = strdup(src);
     if (strchr(pattern, '/')) {
-        while (*pattern != '*') {
-            if (*pattern == '\0')
-                return NULL;
+        while (*pattern != '*' && *pattern != '\0') {
             pattern++;
         }
     }
@@ -58,20 +64,49 @@ static char *get_pattern(char *src)
     return new_pattern;
 }
 
-int globbings(ast_node_t *node)
+static void replace_arg_with_matches(ast_node_t *node, int arg_idx, char **matches, int match_count)
 {
-    if (is_globbings_pattern(node->data.command->argv[1]) == 0)
-        return 0;
+    int arg_count = 0;
+    int new_arg_count = 0;
+    char **new_argv = NULL;
+    int i;
+
+    while (node->data.command->argv[arg_count] != NULL)
+        arg_count++;
+    new_arg_count = arg_count - 1 + match_count;
+    new_argv = malloc(sizeof(char *) * (new_arg_count + 1));
+    if (!new_argv)
+        return;
+    for (i = 0; i < arg_idx; i++)
+        new_argv[i] = node->data.command->argv[i];
+    for (int j = 0; j < match_count; j++) {
+        new_argv[i] = strdup(matches[j]);
+        i++;
+    }
+    for (int j = arg_idx + 1; j < arg_count; j++) {
+        new_argv[i] = node->data.command->argv[j];
+        i++;
+    }
+    new_argv[i] = NULL;
+    free(node->data.command->argv[arg_idx]);
+    free(node->data.command->argv);
+    node->data.command->argv = new_argv;
+}
+
+static void put_globbings(ast_node_t *node, int i)
+{
     int count = 0;
     char **files = NULL;
     char **selected_file = NULL;
-    char *pattern = get_pattern(node->data.command->argv[1]);
+    char *pattern = get_pattern(node->data.command->argv[i]);
+    char *original_arg = strdup(node->data.command->argv[i]);
+    int selected_count = 0;
 
-    if (node->data.command->argv[1][0] == '*') {
-        node->data.command->argv[1][0] = '.';
+    if (node->data.command->argv[i][0] == '*') {
+        node->data.command->argv[i][0] = '.';
     }
-    if (node->data.command->argv[1][strlen(node->data.command->argv[1]) - 1] == '*' ||
-        node->data.command->argv[1][0] == '.') {
+    if (node->data.command->argv[i][strlen(node->data.command->argv[i]) - 1]
+    == '*' || node->data.command->argv[i][0] == '.') {
         printf("in directory\n");
         files = get_directory(node->data.command->argv[1], &count);
     } else {
@@ -82,6 +117,16 @@ int globbings(ast_node_t *node)
         printf("file found : %s\n", files[i]);
     }
     selected_file = get_selected_files(files, pattern, count);
+    if (selected_file != NULL) {
+        while (selected_file[selected_count] != NULL)
+            selected_count++;
+    }
+    if (selected_count > 0) {
+        replace_arg_with_matches(node, i, selected_file, selected_count);
+    } else {
+        free(node->data.command->argv[i]);
+        node->data.command->argv[i] = original_arg;
+    }
     for (int i = 0; selected_file[i] != NULL; i++) {
         printf("selected file : %s\n", selected_file[i]);
         free(selected_file[i]);
@@ -91,6 +136,16 @@ int globbings(ast_node_t *node)
         free(files[i]);
     }
     free(files);
+    free(pattern);
     files = NULL;
 }
 
+int globbings(ast_node_t *node)
+{
+    for (int i = 1; node->data.command->argv[i] != NULL; i++) {
+        if (is_globbings_pattern(node->data.command->argv[i]) == 0)
+            continue;
+        put_globbings(node, i);
+        printf("argv[%i] = %s\n", i, node->data.command->argv[i]);
+    }
+}

--- a/src/globbings/globbings.c
+++ b/src/globbings/globbings.c
@@ -12,25 +12,85 @@
 #include <ftw.h>
 #include <string.h>
 
-static int check_globbings(ast_node_t *node)
+static int is_globbings_pattern(char *pattern)
 {
-    if (node->type != NODE_COMMAND)
-        return -1;
-    for (int i = 1; node->data.command->argv[i]; i++) {
-        if (fnmatch("*.c", node->data.command->argv[i], 0) == 0)
-            printf("in the if \n");
+    if (pattern == NULL)
+        return 0;
+    if (strchr(pattern, '*') != NULL || strchr(pattern, '?') != NULL)
+        return 1;
+    return 0;
+}
+
+static char **get_selected_files(char **files, char *pattern, int count_files)
+{
+    char **selected_files = NULL;
+    int count = 0;
+
+    for (int i = 0; i < count_files; i++) {
+        if (fnmatch(pattern, files[i], 0) == 0) {
+            count++;
+            selected_files = realloc(selected_files, sizeof(char *) * (count + 1));
+            selected_files[count - 1] = strdup(files[i]);
+        }
     }
+    if (selected_files != NULL)
+        selected_files[count] = NULL;
+    return selected_files;
+}
+
+static char *get_pattern(char *src)
+{
+    if (src == NULL)
+        return NULL;
+    char *pattern = strdup(src);
+    char *new_pattern;
+
+    if (strchr(pattern, '/')) {
+        while (*pattern != '*') {
+            if (*pattern == '\0')
+                return NULL;
+            pattern++;
+        }
+    }
+    new_pattern = strdup(pattern);
+    if (new_pattern == NULL)
+        return NULL;
+    return new_pattern;
 }
 
 int globbings(ast_node_t *node)
 {
+    if (is_globbings_pattern(node->data.command->argv[1]) == 0)
+        return 0;
     int count = 0;
-    char **files;
+    char **files = NULL;
+    char **selected_file = NULL;
+    char *pattern = get_pattern(node->data.command->argv[1]);
 
-    printf("start globbings\n");
-    files = get_files(node->data.command->argv[1], &count);
-    for (int i = 0; files[i]; i++) {
+    if (node->data.command->argv[1][0] == '*') {
+        node->data.command->argv[1][0] = '.';
+    }
+    if (node->data.command->argv[1][strlen(node->data.command->argv[1]) - 1] == '*' ||
+        node->data.command->argv[1][0] == '.') {
+        printf("in directory\n");
+        files = get_directory(node->data.command->argv[1], &count);
+    } else {
+        files = get_files(node->data.command->argv[1], &count);
+    }
+    printf("count = %i\n", count);
+    for (int i = 0; i < count; i++) {
+        printf("file found : %s\n", files[i]);
+    }
+    selected_file = get_selected_files(files, pattern, count);
+    for (int i = 0; selected_file[i] != NULL; i++) {
+        printf("selected file : %s\n", selected_file[i]);
+        free(selected_file[i]);
+    }
+    free(selected_file);
+    for (int i = 0; i < count; i++) {
         free(files[i]);
     }
+    free(files);
+    files = NULL;
 }
 

--- a/src/globbings/globbings.c
+++ b/src/globbings/globbings.c
@@ -9,6 +9,8 @@
 #include "globbings.h"
 #include <stdio.h>
 #include <fnmatch.h>
+#include <ftw.h>
+#include <string.h>
 
 static int check_globbings(ast_node_t *node)
 {
@@ -25,5 +27,10 @@ int globbings(ast_node_t *node)
     int count = 0;
     char **files;
 
+    printf("start globbings\n");
     files = get_files(node->data.command->argv[1], &count);
+    for (int i = 0; files[i]; i++) {
+        free(files[i]);
+    }
 }
+

--- a/src/globbings/globbings.c
+++ b/src/globbings/globbings.c
@@ -144,6 +144,9 @@ void globbings(ast_node_t *node)
     if (!node || !node->data.command || !node->data.command->argv) {
         return;
     }
+    if (node->type != NODE_COMMAND) {
+        return;
+    }
     for (int i = 1; node->data.command->argv[i] != NULL; i++) {
         if (is_globbings_pattern(node->data.command->argv[i]) == 0)
             continue;

--- a/src/globbings/globbings.c
+++ b/src/globbings/globbings.c
@@ -1,0 +1,29 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** globbings
+*/
+
+#include "ast.h"
+#include "globbings.h"
+#include <stdio.h>
+#include <fnmatch.h>
+
+static int check_globbings(ast_node_t *node)
+{
+    if (node->type != NODE_COMMAND)
+        return -1;
+    for (int i = 1; node->data.command->argv[i]; i++) {
+        if (fnmatch("*.c", node->data.command->argv[i], 0) == 0)
+            printf("in the if \n");
+    }
+}
+
+int globbings(ast_node_t *node)
+{
+    int count = 0;
+    char **files;
+
+    files = get_files(node->data.command->argv[1], &count);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "globbings.h"
+
 
 static void display_prompt(void)
 {
@@ -30,7 +30,6 @@ static void handle_user_input(shell_t *shell_info, char *user_input)
             free(user_input);
             return;
         }
-        globbings(ast);
         process_command(ast, shell_info);
         free(user_input);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -33,7 +33,6 @@ static void main_loop(shell_t *shell_info)
             break;
         if (user_input[0] != '\n') {
             ast = built_ast_struct(user_input);
-            //printf("%s\n", ast->data.command->argv[1]);
             globbings(ast);
             process_command(ast, shell_info);
             free(user_input);

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "globbings.h"
+
 static void display_prompt(void)
 {
     write(STDOUT_FILENO, "$>", 2);
@@ -31,6 +33,8 @@ static void main_loop(shell_t *shell_info)
             break;
         if (user_input[0] != '\n') {
             ast = built_ast_struct(user_input);
+            //printf("%s\n", ast->data.command->argv[1]);
+            globbings(ast);
             process_command(ast, shell_info);
             free(user_input);
         }

--- a/src_for_tests.list
+++ b/src_for_tests.list
@@ -42,3 +42,6 @@ src/builtins/builtin_exit.c
 src/utils/printf_flush.c
 src/builtins/builtin_history.c
 src/parser/error_handling/pipe_error_handling.c
+src/globbings/get_file.c
+src/globbings/globbings.c
+src/globbings/get_directory.c

--- a/tester/test_main.c
+++ b/tester/test_main.c
@@ -1,0 +1,17 @@
+/*
+** EPITECH PROJECT, 2025
+** clonerepo [WSL: Ubuntu-24.04]
+** File description:
+** test_main
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include "shell.h"
+#include <stdio.h>
+
+void redirect_all_std(void)
+{
+    cr_redirect_stdout();
+    cr_redirect_stderr();
+}

--- a/tests/globbings/test_globbings_getdirectory.c
+++ b/tests/globbings/test_globbings_getdirectory.c
@@ -24,19 +24,19 @@ Test(get_directory, wrong_directory)
 Test(get_directory, simple_directory)
 {
     int count = 0;
-    char **files = get_directory("src/", &count);
+    char **files = get_directory("tests/globbings/", &count);
 
     cr_assert_not_null(files);
-    cr_assert_eq(count, 10);
+    cr_assert_eq(count, 4);
     free(files);
 }
 
 Test(get_directory, directory_without_trailing_slash)
 {
     int count = 0;
-    char **files = get_directory("src", &count);
+    char **files = get_directory("tests/globbings", &count);
 
     cr_assert_not_null(files);
-    cr_assert_eq(count, 10);
+    cr_assert_eq(count, 4);
     free(files);
 }

--- a/tests/globbings/test_globbings_getdirectory.c
+++ b/tests/globbings/test_globbings_getdirectory.c
@@ -1,0 +1,42 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** test_globbings_getdirectory
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/hooks.h>
+#include <stdlib.h>
+#include <string.h>
+#include "shell.h"
+#include "globbings.h"
+
+Test(get_directory, wrong_directory)
+{
+    int count = 0;
+    char **files = get_directory("hsdf", &count);
+
+    cr_assert_null(files);
+    cr_assert_eq(count, 0);
+}
+
+Test(get_directory, simple_directory)
+{
+    int count = 0;
+    char **files = get_directory("src/", &count);
+
+    cr_assert_not_null(files);
+    cr_assert_eq(count, 10);
+    free(files);
+}
+
+Test(get_directory, directory_without_trailing_slash)
+{
+    int count = 0;
+    char **files = get_directory("src", &count);
+
+    cr_assert_not_null(files);
+    cr_assert_eq(count, 10);
+    free(files);
+}

--- a/tests/globbings/test_globbings_getfiles.c
+++ b/tests/globbings/test_globbings_getfiles.c
@@ -1,0 +1,53 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** test_globbings_getfiles
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/hooks.h>
+#include <stdlib.h>
+#include <string.h>
+#include "shell.h"
+#include "globbings.h"
+
+Test(get_files, null_start_path)
+{
+    int count = 0;
+    char **files = get_files(NULL, &count);
+
+    cr_assert_null(files);
+    cr_assert_eq(count, 0);
+}
+
+Test(get_files, empty_start_path)
+{
+    int count = 0;
+    char **files = get_files("", &count);
+
+    cr_assert_null(files);
+    cr_assert_eq(count, 0);
+}
+
+Test(get_files, no_globbing)
+{
+    int count = 0;
+    char **files = get_files("test.txt", &count);
+
+    cr_assert_null(files);
+    cr_assert_eq(count, 0);
+}
+
+Test(get_files, single_globbing)
+{
+    int count = 0;
+    char **files = get_files("src/", &count);
+
+    cr_assert_not_null(files);
+    cr_assert_eq(count, 1);
+    cr_assert_str_eq(files[0], "src/main.c");
+    free(files[0]);
+    free(files);
+}
+

--- a/tests/globbings/test_globbings_main_function.c
+++ b/tests/globbings/test_globbings_main_function.c
@@ -59,14 +59,14 @@ Test(globbings, simple_directory)
     node->data.command = malloc(sizeof(command_t));
     node->data.command->argv = malloc(sizeof(char *) * 3);
     node->data.command->argv[0] = strdup("ls");
-    node->data.command->argv[1] = strdup("src/*");
+    node->data.command->argv[1] = strdup("tests/globbings/*");
     node->data.command->argv[2] = NULL;
 
     globbings(node);
     cr_assert_eq(node->type, NODE_COMMAND);
     int i;
     for (i = 0; node->data.command->argv[i] != NULL; i++);
-    cr_assert_eq(i, 11);
+    cr_assert_eq(i, 5);
     for (int j = 0; j < i; j++) {
         cr_assert_not_null(node->data.command->argv[j]);
     }

--- a/tests/globbings/test_globbings_main_function.c
+++ b/tests/globbings/test_globbings_main_function.c
@@ -1,0 +1,78 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** test_globbings_main_function
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/hooks.h>
+#include <stdlib.h>
+#include <string.h>
+#include "shell.h"
+#include "globbings.h"
+
+Test(globbings, null_node)
+{
+    ast_node_t *node = NULL;
+
+    globbings(node);
+    cr_assert_null(node);
+}
+
+Test(globbings, not_a_command)
+{
+    ast_node_t *node = malloc(sizeof(ast_node_t));
+    node->type = NODE_AND;
+
+    globbings(node);
+    cr_assert_eq(node->type, NODE_AND);
+    free(node);
+}
+
+Test(globbings, simple_list)
+{
+    ast_node_t *node = malloc(sizeof(ast_node_t));
+    node->type = NODE_COMMAND;
+    node->data.command = malloc(sizeof(command_t));
+    node->data.command->argv = malloc(sizeof(char *) * 3);
+    node->data.command->argv[0] = strdup("ls");
+    node->data.command->argv[1] = strdup("src/*.c");
+    node->data.command->argv[2] = NULL;
+
+    globbings(node);
+    cr_assert_eq(node->type, NODE_COMMAND);
+    cr_assert_str_eq(node->data.command->argv[0], "ls");
+    cr_assert_str_eq(node->data.command->argv[1], "src/main.c");
+    cr_assert_null(node->data.command->argv[2]);
+
+    free(node->data.command->argv[0]);
+    free(node->data.command->argv[1]);
+    free(node->data.command);
+    free(node);
+}
+
+Test(globbings, simple_directory)
+{
+    ast_node_t *node = malloc(sizeof(ast_node_t));
+    node->type = NODE_COMMAND;
+    node->data.command = malloc(sizeof(command_t));
+    node->data.command->argv = malloc(sizeof(char *) * 3);
+    node->data.command->argv[0] = strdup("ls");
+    node->data.command->argv[1] = strdup("src/*");
+    node->data.command->argv[2] = NULL;
+
+    globbings(node);
+    cr_assert_eq(node->type, NODE_COMMAND);
+    int i;
+    for (i = 0; node->data.command->argv[i] != NULL; i++);
+    cr_assert_eq(i, 11);
+    for (int j = 0; j < i; j++) {
+        cr_assert_not_null(node->data.command->argv[j]);
+    }
+    for (int j = 0; j < i; j++) {
+        free(node->data.command->argv[j]);
+    }
+    free(node->data.command);
+    free(node);
+}

--- a/tests_src.list
+++ b/tests_src.list
@@ -28,3 +28,6 @@ tests/builtins/test_builtin_echo.c
 tests/builtins/test_builtin_env.c
 tests/builtins/test_builtin_exit.c
 tests/builtins/test_builtins.c
+tests/globbings/test_globbings_getfiles.c
+tests/globbings/test_globbings_getdirectory.c
+tests/globbings/test_globbings_main_function.c


### PR DESCRIPTION
This pull request introduces a new feature for handling globbing patterns in the shell, including the implementation of several utility functions and integration into the main execution flow. The most significant changes involve adding the `globbings` module, which processes wildcard patterns in command arguments, and modifying the main loop to utilize this new functionality.

### New Feature: Globbing Support
* **Header File for Globbing**: Added `globbings.h` to define the `globbings` module's interface and its supporting structures and functions. This includes functions for retrieving files, processing directories, and freeing resources. (`include/globbings.h`)
* **Core Globbing Logic**: Implemented the `globbings` function in `globbings.c` to replace command arguments containing globbing patterns (e.g., `*`, `?`) with matching file paths. (`src/globbings/globbings.c`)

### Utility Functions for File Handling
* **Directory Processing**: Added `get_directory` in `get_directory.c` to retrieve files from a directory based on a path. (`src/globbings/get_directory.c`)
* **Recursive File Retrieval**: Added `get_files` in `get_file.c` to recursively retrieve files matching globbing patterns. This includes helper functions for path joining and directory traversal. (`src/globbings/get_file.c`)

### Integration into Main Execution Flow
* **Main Loop Update**: Integrated the `globbings` function into the main execution loop to process and expand globbing patterns in user commands. (`src/main.c`)
* **Header Inclusion**: Included the `globbings.h` header in `main.c` to enable the use of the globbing functionality. (`src/main.c`)

### Build System Update
* **Source List Update**: Added the new globbing-related source files (`get_file.c`, `globbings.c`, `get_directory.c`) to the build system. (`src.list`)