### PR TITLE
refactor: update built_ast_struct to accept shell_info and improve error handling

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -49,7 +49,7 @@ typedef struct history_s {
     int capacity;
 } history_t;
 
-ast_node_t *built_ast_struct(char *user_input);
+ast_node_t *built_ast_struct(char *user_input, shell_t *shell_info);
 int process_command(ast_node_t *ast, shell_t *shell_info);
 char *read_command(shell_t *shell, bool *had_error);
 void printf_flush(const char *format, ...);

--- a/src/command_execution/execute_command.c
+++ b/src/command_execution/execute_command.c
@@ -24,6 +24,7 @@ static void child_process(
     execve(full_path, node->data.command->argv, shell_var->env_array);
     handle_command_not_found(node->data.command->argv[0]);
     shell_var->exit_code = 1;
+    exit(1);
 }
 
 int execute_builtin(ast_node_t *node, struct shell_s *shell_var)

--- a/src/command_execution/execute_command.c
+++ b/src/command_execution/execute_command.c
@@ -23,6 +23,7 @@ static void child_process(
 {
     execve(full_path, node->data.command->argv, shell_var->env_array);
     handle_command_not_found(node->data.command->argv[0]);
+    shell_var->exit_code = 1;
 }
 
 int execute_builtin(ast_node_t *node, struct shell_s *shell_var)

--- a/src/main.c
+++ b/src/main.c
@@ -23,7 +23,7 @@ static void handle_user_input(shell_t *shell_info, char *user_input)
     ast_node_t *ast;
 
     if (user_input && user_input[0] != '\n') {
-        ast = built_ast_struct(user_input);
+        ast = built_ast_struct(user_input, shell_info);
         if (ast == NULL) {
             free(user_input);
             return;

--- a/src/main_loop/handle_user_input.c
+++ b/src/main_loop/handle_user_input.c
@@ -83,6 +83,7 @@ ast_node_t *built_ast_struct(char *user_input, shell_t *shell_info)
     ast = parse_sequence(tokens, &pos);
     if (ast_error_handling(ast) != 0) {
         shell_info->exit_code = 1;
+        free(tokens);
         return NULL;
     }
     if (!ast) {

--- a/src/main_loop/handle_user_input.c
+++ b/src/main_loop/handle_user_input.c
@@ -56,23 +56,38 @@ char *read_command(shell_t *shell, bool *had_error)
     return line;
 }
 
-ast_node_t *built_ast_struct(char *user_input)
+static bool handle_user_input_errors(char **tokens, shell_t *shell_info)
+{
+    if (user_input_error_handling(tokens) != 0) {
+        shell_info->exit_code = 1;
+        return true;
+    }
+    if (!tokens) {
+        fprintf(stderr, "Lexer failed\n");
+        return true;
+    }
+    return false;
+}
+
+ast_node_t *built_ast_struct(char *user_input, shell_t *shell_info)
 {
     char **tokens;
     ast_node_t *ast;
     int pos = 0;
 
-    tokens = lexer(user_input);
-    if (user_input_error_handling(tokens) != 0)
+    if (!user_input || user_input[0] == '\0')
         return NULL;
-    if (!tokens) {
-        fprintf(stderr, "Lexer failed\n");
+    tokens = lexer(user_input);
+    if (handle_user_input_errors(tokens, shell_info))
+        return NULL;
+    ast = parse_sequence(tokens, &pos);
+    if (ast_error_handling(ast) != 0) {
+        shell_info->exit_code = 1;
         return NULL;
     }
-    ast = parse_sequence(tokens, &pos);
-    if (ast_error_handling(ast) != 0)
+    if (!ast) {
+        free(tokens);
         return NULL;
-    if (!ast)
-        return NULL;
+    }
     return ast;
 }

--- a/src/parser/parse_redirect.c
+++ b/src/parser/parse_redirect.c
@@ -60,7 +60,7 @@ int process_redirect_node(ast_node_t **node, char **tokens, int *pos)
         return -1;
     (*pos)++;
     if (!tokens[*pos]) {
-        fprintf(stderr, "error: missing filename for redirection\n");
+        fprintf(stderr, "Missing name for redirect.\n");
         return -1;
     }
     filename = tokens[*pos];


### PR DESCRIPTION
This pull request introduces several updates to improve error handling, enhance code modularity, and refine process management in the shell application. Key changes include adding error handling for user input and AST parsing, refactoring child process management for better exit code handling, and improving modularity by introducing helper functions. Below is a categorized summary of the most important changes:

### Error Handling Improvements:
* Refactored `built_ast_struct` to include `shell_t *shell_info` for better error handling and to set the shell's `exit_code` on errors. Introduced a helper function `handle_user_input_errors` to streamline error handling for tokenization and lexing (`src/main_loop/handle_user_input.c`).
* Updated error message in `process_redirect_node` to make it like tcsh(`src/parser/parse_redirect.c`).

### Process Management Enhancements:
* Added logic to set `shell_var->exit_code` to `1` when a command is not found in `child_process` (`src/command_execution/execute_command.c`).
* Modified `execute_child_command` to ensure the child process exits with code `1` on failure, and updated the return value of the function to reflect success or failure (`src/command_execution/pipe/execute_pipe_command.c`).

### Modularity and Code Simplification:
* Refactored `execute_pipe` by extracting child process waiting logic into a new helper function `wait_for_children`, improving readability and maintainability (`src/command_execution/pipe/execute_pipe_command.c`). [[1]](diffhunk://#diff-2573da8a1859025491e975b7ea8f6732e4e0620475bb60bd73a0b27645b809f0L112-R132) [[2]](diffhunk://#diff-2573da8a1859025491e975b7ea8f6732e4e0620475bb60bd73a0b27645b809f0L127-R142)

### Function Signature Updates:
* Updated `built_ast_struct` to take an additional `shell_t *shell_info` parameter to align with the new error handling design (`include/shell.h`, `src/main.c`). [[1]](diffhunk://#diff-27d16b23443749eb94db58305d3c6c13b9b251dc1551f00e587d10754e1d31a8L52-R52) [[2]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L26-R26)