### PR TITLE
feat(command): add subshell command execution functionality

### DIFF
--- a/include/command.h
+++ b/include/command.h
@@ -44,6 +44,7 @@ int execute_sequence(ast_node_t *ast, shell_t *shell_info);
 int execute_redirect(ast_node_t *node, struct shell_s *shell_var);
 void (*get_redirect_handler(redirect_type_t type))(char *);
 int execute_builtin(ast_node_t *node, struct shell_s *shell_var);
+int execute_subshell_command(ast_node_t *ast, shell_t *shell_var);
 
 char *build_path(shell_t *shell, char *command);
 char *my_strcat(char *dest, char const *str);

--- a/src.list
+++ b/src.list
@@ -48,3 +48,4 @@ src/builtins/builtin_exit.c
 src/utils/printf_flush.c
 src/builtins/builtin_history.c
 src/parser/error_handling/pipe_error_handling.c
+src/command_execution/execute_subshell_command.c

--- a/src/command_execution/execute_subshell_command.c
+++ b/src/command_execution/execute_subshell_command.c
@@ -1,0 +1,36 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** execute_subshell_command
+*/
+
+#include "command.h"
+#include "shell.h"
+#include "ast.h"
+#include <sys/wait.h>
+#include <unistd.h>
+#include <stdio.h>
+
+int execute_subshell_command(ast_node_t *ast, shell_t *shell_var)
+{
+    int exit_code = 0;
+    ast_node_t *subshell = ast->data.binop.left;
+    pid_t pid = fork();
+
+    if (subshell == NULL)
+        return 0;
+    if (pid == -1)
+        return -1;
+    if (pid == 0)
+        exit(process_command(subshell, shell_var));
+    waitpid(pid, &exit_code, 0);
+    if (WIFEXITED(exit_code))
+        exit_code = WEXITSTATUS(exit_code);
+    else if (WIFSIGNALED(exit_code)) {
+        handle_exit_status(exit_code);
+        exit_code = 128 + WTERMSIG(exit_code);
+    }
+    shell_var->exit_code = exit_code;
+    return shell_var->exit_code;
+}

--- a/src/main_loop/process_command.c
+++ b/src/main_loop/process_command.c
@@ -18,6 +18,7 @@ int process_command(ast_node_t *ast, shell_t *shell_info)
         [NODE_AND] = execute_and,
         [NODE_SEQUENCE] = execute_sequence,
         [NODE_REDIRECT] = execute_redirect,
+        [NODE_SUBSHELL] = execute_subshell_command,
     };
 
     if (ast == NULL)

--- a/src_for_tests.list
+++ b/src_for_tests.list
@@ -42,3 +42,4 @@ src/builtins/builtin_exit.c
 src/utils/printf_flush.c
 src/builtins/builtin_history.c
 src/parser/error_handling/pipe_error_handling.c
+src/command_execution/execute_subshell_command.c


### PR DESCRIPTION
This pull request introduces support for executing subshell commands in the shell implementation. The main changes include adding a new function to handle subshell execution, updating the AST node processing logic, and registering the new functionality in the build system.

### New feature: Subshell command execution
* Added the `execute_subshell_command` function in `src/command_execution/execute_subshell_command.c` to handle the execution of subshell commands. This function forks a new process to execute the subshell, manages the exit status, and updates the shell's state accordingly.
* Declared the `execute_subshell_command` function in the `command.h` header file to make it accessible throughout the project.

### Integration with AST processing
* Updated the `process_command` function in `src/main_loop/process_command.c` to include a new case for `NODE_SUBSHELL`, delegating the handling of subshell commands to the `execute_subshell_command` function.

### Build system update
* Registered the new `execute_subshell_command.c` file in the build system by adding it to the `src.list` file.