### PR TITLE
fix(command_execution): update execute_and function to return the exit code of the first command

### DIFF
--- a/src/command_execution/execute_and_command.c
+++ b/src/command_execution/execute_and_command.c
@@ -10,7 +10,9 @@
 
 int execute_and(ast_node_t *ast, shell_t *shell_info)
 {
-    if (process_command(ast->data.binop.left, shell_info) == 0)
+    int exit_code = process_command(ast->data.binop.left, shell_info);
+
+    if (exit_code == 0)
         return process_command(ast->data.binop.right, shell_info);
-    return -1;
+    return exit_code;
 }


### PR DESCRIPTION
This pull request refines the logic in the `execute_and` function to improve clarity and ensure the correct exit code is returned. 

Key changes:

* [`src/command_execution/execute_and_command.c`](diffhunk://#diff-45e1afbb8ec438b8068fd662cc3c2974d9fb88609774193cb69c59929e4755efL13-R17): Introduced a local variable `exit_code` to store the result of `process_command` for the left operand. This ensures that the function returns the correct exit code when the left operand fails, rather than always returning `-1`.