### PR TITLE
hotfix(path_handling): handle path environnement variable on /commands

### DIFF
--- a/include/env.h
+++ b/include/env.h
@@ -17,6 +17,7 @@ void unset_env_value(shell_t *shell, const char *var);
 char *get_local_value(shell_t *shell, const char *var);
 void set_local_value(shell_t *shell, const char *var, const char *value);
 void unset_local_value(shell_t *shell, const char *var);
-
+char *my_getenv(const char *name, char **env);
+char *get_path(char **env);
 
 #endif

--- a/src.list
+++ b/src.list
@@ -52,3 +52,4 @@ src/utils/printf_flush.c
 src/builtins/builtin_history.c
 src/parser/error_handling/pipe_error_handling.c
 src/command_execution/execute_subshell_command.c
+src/command_execution/utils/path.c

--- a/src/builtins/builtin_env.c
+++ b/src/builtins/builtin_env.c
@@ -10,6 +10,16 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "env.h"
+
+char *my_getenv(char const *name, char **env)
+{
+    for (int i = 0; env[i]; i++) {
+        if (strncmp(name, env[i], strlen(name)) == 0)
+            return env[i] + strlen(name) + 1;
+    }
+    return NULL;
+}
 
 int builtin_env(shell_t *shell, char **args)
 {

--- a/src/command_execution/get_command_path.c
+++ b/src/command_execution/get_command_path.c
@@ -11,6 +11,7 @@
 #include "shell.h"
 #include "command.h"
 #include "env.h"
+
 /**
  * @brief Expand tilde (~) in path to home directory
  * @param path Path that may contain tilde

--- a/src/command_execution/get_command_path.c
+++ b/src/command_execution/get_command_path.c
@@ -10,7 +10,7 @@
 #include <string.h>
 #include "shell.h"
 #include "command.h"
-
+#include "env.h"
 /**
  * @brief Expand tilde (~) in path to home directory
  * @param path Path that may contain tilde
@@ -125,12 +125,12 @@ static int check_command_in_path(char *path_str, path_search_t *search)
  */
 char *build_path(shell_t *shell, char *command)
 {
-    char *path = getenv("PATH");
+    char *path = get_path(shell->env_array);
     path_search_t search = {0};
     int result;
 
-    if (!path)
-        path = DEFAULT_PATH;
+    if (strrchr(command, '/') != NULL)
+        return command;
     search.command = command;
     search.shell = shell;
     search.result_path = NULL;

--- a/src/command_execution/utils/path.c
+++ b/src/command_execution/utils/path.c
@@ -1,0 +1,21 @@
+/*
+** EPITECH PROJECT, 2025
+** 42sh
+** File description:
+** path
+*/
+
+#include "shell.h"
+#include "command.h"
+#include <string.h>
+#include "env.h"
+
+char *get_path(char **env)
+{
+    char *path = my_getenv("PATH", env);
+
+    if (!path)
+        path = DEFAULT_PATH;
+    return path;
+}
+

--- a/src/command_execution/utils/path.c
+++ b/src/command_execution/utils/path.c
@@ -18,4 +18,3 @@ char *get_path(char **env)
         path = DEFAULT_PATH;
     return path;
 }
-

--- a/src_for_tests.list
+++ b/src_for_tests.list
@@ -46,3 +46,4 @@ src/globbings/get_file.c
 src/globbings/globbings.c
 src/globbings/get_directory.c
 src/command_execution/execute_subshell_command.c
+src/command_execution/utils/path.c


### PR DESCRIPTION
This pull request introduces functionality to retrieve environment variables and refactors how the `PATH` environment variable is handled in the shell. The most significant changes include the addition of utility functions for environment variable access, integration of these functions into command path resolution, and the necessary updates to include files and build configuration.

### Environment Variable Utilities:

* Added `my_getenv` function to retrieve the value of an environment variable from a given environment array. (`src/builtins/builtin_env.c`, [src/builtins/builtin_env.cR13-R22](diffhunk://#diff-de295ba2ebe8c3aa5443e5d2cd9b83fce3c7b47073bb69ad02ebe68beb51c3edR13-R22))
* Added `get_path` function to retrieve the `PATH` environment variable, with a fallback to `DEFAULT_PATH` if it is not set. (`src/command_execution/utils/path.c`, [src/command_execution/utils/path.cR1-R20](diffhunk://#diff-cd703c291c9acc1b2f3f77f73accae58d2f8311b5983867b082d59f8c84b2f1eR1-R20))

### Refactoring Command Path Resolution:

* Replaced direct use of `getenv("PATH")` with the new `get_path` function in `build_path`, improving modularity and testability. (`src/command_execution/get_command_path.c`, [src/command_execution/get_command_path.cL128-R133](diffhunk://#diff-d37a73b7da38fb2014a93a16ee2e6515b9d6b995b564cd10748423221c7b2210L128-R133))

### Build and Header Updates:

* Updated `include/env.h` to declare the new utility functions `my_getenv` and `get_path`.
* Updated source file includes to reference `env.h` where needed, ensuring access to the new utility functions. (`src/builtins/builtin_env.c`, [[1]](diffhunk://#diff-de295ba2ebe8c3aa5443e5d2cd9b83fce3c7b47073bb69ad02ebe68beb51c3edR13-R22); `src/command_execution/get_command_path.c`, [[2]](diffhunk://#diff-d37a73b7da38fb2014a93a16ee2e6515b9d6b995b564cd10748423221c7b2210L13-R13)
* Added `src/command_execution/utils/path.c` to the build configuration in `src.list`.