### PR TITLE
fix(pipe): fix cleaning pipe at run time

### DIFF
--- a/src/command_execution/pipe/execute_pipe_command.c
+++ b/src/command_execution/pipe/execute_pipe_command.c
@@ -20,6 +20,7 @@ static int execute_child_command(command_info_t *command_info, int i,
 {
     ast_node_t *node = command_info->commands[i];
     char *full_path = build_path(shell_var, node->data.command->argv[0]);
+    int return_value = 0;
 
     if (!full_path) {
         handle_command_not_found(node->data.command->argv[0]);
@@ -27,9 +28,9 @@ static int execute_child_command(command_info_t *command_info, int i,
     }
     if (command_info->pids[i] == 0) {
         if (is_builtin_cmd(node)) {
-            execute_builtin(node, shell_var);
+            return_value = execute_builtin(node, shell_var);
             free(full_path);
-            exit(0);
+            exit(return_value);
         }
         execve(full_path, node->data.command->argv, shell_var->env_array);
         handle_command_not_found(node->data.command->argv[0]);

--- a/src/command_execution/pipe/execute_pipe_command.c
+++ b/src/command_execution/pipe/execute_pipe_command.c
@@ -15,14 +15,6 @@
 #include <string.h>
 #include <signal.h>
 
-static void close_pipes(int pipes[][2], int count)
-{
-    for (int i = 0; i < count; i++) {
-        close(pipes[i][0]);
-        close(pipes[i][1]);
-    }
-}
-
 static int execute_child_command(command_info_t *command_info, int i,
     shell_t *shell_var)
 {
@@ -45,37 +37,78 @@ static int execute_child_command(command_info_t *command_info, int i,
     return 1;
 }
 
-static void handle_child_process(int i, command_info_t *command_info,
-    struct shell_s *shell_var)
+static void setup_child_pipes(int prev_pipe[2], int curr_pipe[2])
 {
-    if (i > 0)
-        dup2(command_info->pipes[i - 1][0], STDIN_FILENO);
-    if (i < command_info->command_count - 1)
-        dup2(command_info->pipes[i][1], STDOUT_FILENO);
-    close_pipes(command_info->pipes, command_info->command_count - 1);
-    execute_child_command(command_info, i, shell_var);
-    exit(1);
+    if (prev_pipe[0] != -1) {
+        dup2(prev_pipe[0], STDIN_FILENO);
+        close(prev_pipe[0]);
+    }
+    if (prev_pipe[1] != -1)
+        close(prev_pipe[1]);
+    if (curr_pipe[1] != -1) {
+        dup2(curr_pipe[1], STDOUT_FILENO);
+        close(curr_pipe[1]);
+    }
+    if (curr_pipe[0] != -1)
+        close(curr_pipe[0]);
+}
+
+static void close_parent_pipes(int prev_pipe[2])
+{
+    if (prev_pipe[0] != -1)
+        close(prev_pipe[0]);
+    if (prev_pipe[1] != -1)
+        close(prev_pipe[1]);
+}
+
+static int create_pipe_if_needed(int curr_pipe[2], int prev_pipe[2], int i,
+    int command_count)
+{
+    curr_pipe[0] = -1;
+    curr_pipe[1] = -1;
+    if (i < command_count - 1) {
+        if (pipe(curr_pipe) == -1) {
+            perror("pipe");
+            close_parent_pipes(prev_pipe);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int handle_fork_error(int prev_pipe[2], int curr_pipe[2])
+{
+    perror("fork");
+    close_parent_pipes(prev_pipe);
+    if (curr_pipe[0] != -1)
+        close(curr_pipe[0]);
+    if (curr_pipe[1] != -1)
+        close(curr_pipe[1]);
+    return -1;
 }
 
 static int setup_pipes_and_fork(command_info_t *command_info,
     struct shell_s *shell_var)
 {
-    for (int i = 0; i < command_info->command_count - 1; i++) {
-        if (pipe(command_info->pipes[i]) == -1) {
-            perror("pipe");
-            return -1;
-        }
-    }
+    int prev_pipe[2] = {-1, -1};
+    int curr_pipe[2];
+
     for (int i = 0; i < command_info->command_count; i++) {
-        command_info->pids[i] = fork();
-        if (command_info->pids[i] == -1) {
-            perror("fork");
-            close_pipes(command_info->pipes, command_info->command_count - 1);
+        if (create_pipe_if_needed(curr_pipe, prev_pipe, i,
+            command_info->command_count) == -1)
             return -1;
+        command_info->pids[i] = fork();
+        if (command_info->pids[i] == -1)
+            return handle_fork_error(prev_pipe, curr_pipe);
+        if (command_info->pids[i] == 0) {
+            setup_child_pipes(prev_pipe, curr_pipe);
+            execute_child_command(command_info, i, shell_var);
         }
-        if (command_info->pids[i] == 0)
-            handle_child_process(i, command_info, shell_var);
+        close_parent_pipes(prev_pipe);
+        prev_pipe[0] = curr_pipe[0];
+        prev_pipe[1] = curr_pipe[1];
     }
+    close_parent_pipes(prev_pipe);
     return 0;
 }
 
@@ -138,7 +171,6 @@ int execute_pipe(ast_node_t *node, struct shell_s *shell_var)
         cleanup_command_info(command_info);
         return -1;
     }
-    close_pipes(command_info->pipes, command_info->command_count - 1);
     last_status = wait_for_children(command_info, shell_var);
     cleanup_command_info(command_info);
     return last_status;

--- a/src/command_execution/pipe/execute_pipe_command.c
+++ b/src/command_execution/pipe/execute_pipe_command.c
@@ -21,15 +21,16 @@ static int execute_child_command(command_info_t *command_info, int i,
     ast_node_t *node = command_info->commands[i];
     char *full_path = build_path(shell_var, node->data.command->argv[0]);
 
-    if (is_builtin_cmd(node)) {
-        free(full_path);
-        exit(execute_builtin(node, shell_var));
-    }
     if (!full_path) {
         handle_command_not_found(node->data.command->argv[0]);
         exit(1);
     }
     if (command_info->pids[i] == 0) {
+        if (is_builtin_cmd(node)) {
+            execute_builtin(node, shell_var);
+            free(full_path);
+            exit(0);
+        }
         execve(full_path, node->data.command->argv, shell_var->env_array);
         handle_command_not_found(node->data.command->argv[0]);
         exit(1);

--- a/tests/tests
+++ b/tests/tests
@@ -550,6 +550,22 @@ TESTS=
   echo "ls -l | sqfd | wc -l"
 [2114-END]
 
+[2115]
+NAME="PIPE: builtin command with pipe"
+SETUP="export TERM=xterm ; PATH='/bin:/usr/bin'"
+CLEAN=""
+TESTS=
+  echo "history | cat -e"
+[2115-END]
+
+[2116]
+NAME="PIPE: ulimit = 10"
+SETUP="export TERM=xterm ; PATH='/bin:/usr/bin' ; ulimit -n 10"
+CLEAN=""
+TESTS=
+  echo "cat test_main.c | cat | cat | cat | cat | cat | cat | cat | cat | cat"
+[2116-END]
+
 [2201]
 NAME="SEMICOLON: Simple semicolons"
 SETUP="export TERM=xterm ; PATH='/bin:/usr/bin'"


### PR DESCRIPTION
This pull request refactors the pipe execution logic in `execute_pipe_command.c` to improve clarity and modularity, and adds new test cases to validate the changes. The most important changes include splitting and reorganizing pipe and process management functions, modifying the handling of built-in commands, and introducing test cases for edge scenarios.

### Refactoring and modularization of pipe execution logic:
* Removed the `close_pipes` function and replaced it with more specific functions: `close_parent_pipes` and `setup_child_pipes`, to handle pipe closure in a more modular way. (`src/command_execution/pipe/execute_pipe_command.c`, [src/command_execution/pipe/execute_pipe_command.cL18-R112](diffhunk://#diff-2573da8a1859025491e975b7ea8f6732e4e0620475bb60bd73a0b27645b809f0L18-R112))
* Introduced `create_pipe_if_needed` and `handle_fork_error` functions to isolate pipe creation and error handling logic, improving readability and maintainability. (`src/command_execution/pipe/execute_pipe_command.c`, [src/command_execution/pipe/execute_pipe_command.cL18-R112](diffhunk://#diff-2573da8a1859025491e975b7ea8f6732e4e0620475bb60bd73a0b27645b809f0L18-R112))
* Refactored `setup_pipes_and_fork` to use the new helper functions, simplifying the loop that manages pipe setup and process forking. (`src/command_execution/pipe/execute_pipe_command.c`, [src/command_execution/pipe/execute_pipe_command.cL18-R112](diffhunk://#diff-2573da8a1859025491e975b7ea8f6732e4e0620475bb60bd73a0b27645b809f0L18-R112))

### Built-in command handling:
* Moved the handling of built-in commands directly into the child process logic to ensure proper execution and cleanup, avoiding redundant code. (`src/command_execution/pipe/execute_pipe_command.c`, [src/command_execution/pipe/execute_pipe_command.cL18-R112](diffhunk://#diff-2573da8a1859025491e975b7ea8f6732e4e0620475bb60bd73a0b27645b809f0L18-R112))

### Test case additions:
* Added a test case to validate the behavior of a built-in command (`history`) when used in a pipe. (`tests/tests`, [tests/testsR553-R568](diffhunk://#diff-443539a197ffddd0393a0750e4d34f721f14b047c603b938ebf883c60b3710edR553-R568))
* Added a test case to evaluate the behavior of pipes under a restrictive `ulimit` setting (`ulimit -n 10`). (`tests/tests`, [tests/testsR553-R568](diffhunk://#diff-443539a197ffddd0393a0750e4d34f721f14b047c603b938ebf883c60b3710edR553-R568))