### PR TITLE
fix: redirection error handling

### DIFF
--- a/tests/tests
+++ b/tests/tests
@@ -991,3 +991,11 @@ CLEAN="rm -f /tmp/complex_output"
 TESTS=
   echo "ls /etc > /tmp/complex_output && cat /tmp/complex_output || echo failed"
 [3522-END]
+
+[3600]
+NAME="Input redirection from non-existent file"
+SETUP="export TERM=xterm ; PATH='/bin:/usr/bin'"
+CLEAN=""
+TESTS=
+  echo "ls < Make"
+[3600-END]


### PR DESCRIPTION
This pull request refactors the redirection handling in the parser, improves error handling for input redirection, and adds a new test case for input redirection from a non-existent file. The key changes include splitting redirection logic into a helper function, adding file existence checks, and updating the test suite.

### Refactoring and error handling improvements:
* [`src/parser/parse_redirect.c`](diffhunk://#diff-fc9435ef623e953871a9ee122bfa00ca6adea3da0e8550b445c55ecbc9158e55L53-R81): Introduced a new helper function `check_redirect` to encapsulate redirection validation logic, including checks for missing filenames and file existence for input redirection. This improves code readability and error handling.

### Test suite updates:
* [`tests/tests`](diffhunk://#diff-443539a197ffddd0393a0750e4d34f721f14b047c603b938ebf883c60b3710edR994-R1001): Added a new test case to verify behavior when attempting input redirection from a non-existent file. This ensures the parser correctly handles such scenarios and outputs the appropriate error message.

### Dependency updates:
* [`src/parser/parse_redirect.c`](diffhunk://#diff-fc9435ef623e953871a9ee122bfa00ca6adea3da0e8550b445c55ecbc9158e55R10-R11): Added `unistd.h` and `stdlib.h` includes to support the `access` function and other standard library functionality.