### PR TITLE
Fix/double left redirection

### DIFF
--- a/src/command_execution/execute_command.c
+++ b/src/command_execution/execute_command.c
@@ -22,9 +22,15 @@
 static void child_process(
     char *full_path, ast_node_t *node, struct shell_s *shell_var)
 {
-    execve(full_path, node->data.command->argv, shell_var->env_array);
-    handle_command_not_found(node->data.command->argv[0]);
-    shell_var->exit_code = 1;
+    if (node->type == NODE_COMMAND) {
+        printf("ast_command : %s\n", node->data.command->argv[0]);
+        printf("execve: %s\n", full_path);
+        execve(full_path, node->data.command->argv, shell_var->env_array);
+        printf("not found\n");
+        printf("%s: Command not found.\n", node->data.command->argv[0]);
+        handle_command_not_found(node->data.command->argv[0]);
+        shell_var->exit_code = 1;
+    }
     exit(1);
 }
 

--- a/src/command_execution/execute_command.c
+++ b/src/command_execution/execute_command.c
@@ -23,11 +23,7 @@ static void child_process(
     char *full_path, ast_node_t *node, struct shell_s *shell_var)
 {
     if (node->type == NODE_COMMAND) {
-        printf("ast_command : %s\n", node->data.command->argv[0]);
-        printf("execve: %s\n", full_path);
         execve(full_path, node->data.command->argv, shell_var->env_array);
-        printf("not found\n");
-        printf("%s: Command not found.\n", node->data.command->argv[0]);
         handle_command_not_found(node->data.command->argv[0]);
         shell_var->exit_code = 1;
     }

--- a/src/main_loop/process_command.c
+++ b/src/main_loop/process_command.c
@@ -8,6 +8,22 @@
 #include "ast.h"
 #include "command.h"
 #include <stdio.h>
+#include <unistd.h>
+#include <stdbool.h>
+
+static void flush_stdin(ast_node_t *ast)
+{
+    int c;
+
+    if (ast->type == NODE_REDIRECT && ast->data.redir.type == REDIR_HEREDOC) {
+        c = getchar();
+        while (c != EOF && c != '|') {
+            c = getchar();
+        }
+        if (c == '|')
+            ungetc(c, stdin);
+    }
+}
 
 int process_command(ast_node_t *ast, shell_t *shell_info)
 {
@@ -24,5 +40,6 @@ int process_command(ast_node_t *ast, shell_t *shell_info)
     if (ast == NULL)
         return 0;
     shell_info->exit_code = execute_functions[ast->type](ast, shell_info);
+    flush_stdin(ast);
     return shell_info->exit_code;
 }

--- a/tests/tests
+++ b/tests/tests
@@ -1023,3 +1023,36 @@ CLEAN="rm -f /tmp/complex_output"
 TESTS=
   echo "ls /etc > /tmp/complex_output && cat /tmp/complex_output || echo failed"
 [3522-END]
+
+[4001]
+NAME="HEREDOC: Basic heredoc redirection"
+SETUP="export TERM=xterm ; PATH='/bin:/usr/bin'"
+CLEAN=""
+TESTS=
+  echo '/bin/cat << EOF
+Hello World
+This is a heredoc test
+Multiple lines
+EOF'
+[4001-END]
+
+[4003]
+NAME="HEREDOC: With unique delimiter"
+SETUP="export TERM=xterm ; PATH='/bin:/usr/bin'"
+CLEAN=""
+TESTS=
+  echo 'cat << CUSTOM_DELIM
+Line one
+Line two
+CUSTOM_DELIM'
+[4003-END]
+
+[4004]
+NAME="HEREDOC: Empty content"
+SETUP="export TERM=xterm ; PATH='/bin:/usr/bin'"
+CLEAN=""
+TESTS=
+  echo 'cat << EOF
+EOF'
+[4004-END]
+


### PR DESCRIPTION
This pull request introduces support for basic heredoc functionality in the shell, improves command execution handling, and adds new tests to validate the changes. The most significant updates include adding a function to handle heredoc input flushing, modifying the command execution logic to ensure proper handling of specific node types, and introducing new test cases for heredoc scenarios.

### Heredoc Support and Input Handling:

* [`src/main_loop/process_command.c`](diffhunk://#diff-a0ee54e7a7b25cb7408c5c894298d4045389caed344220a980ef3f7693afa273R11-R26): Added a new `flush_stdin` function to handle flushing of stdin for heredoc redirection nodes. This ensures that input is processed correctly when a heredoc is encountered. The function is called in `process_command` after executing the command. [[1]](diffhunk://#diff-a0ee54e7a7b25cb7408c5c894298d4045389caed344220a980ef3f7693afa273R11-R26) [[2]](diffhunk://#diff-a0ee54e7a7b25cb7408c5c894298d4045389caed344220a980ef3f7693afa273R43)

### Command Execution Improvements:

* [`src/command_execution/execute_command.c`](diffhunk://#diff-7ec179470b999a33a88970541215902260c01608c289785c39dc2c8c18cc1e88R25-R29): Updated the `child_process` function to add a conditional check for `NODE_COMMAND` before calling `execve`. This ensures that only valid command nodes are executed.

### Test Enhancements:

* `tests/tests`: Added three new test cases to validate heredoc functionality:
  - Basic heredoc redirection.
  - Heredoc with a unique delimiter.
  - Heredoc with empty content.
  These tests ensure that the new functionality works as expected in different scenarios.

### The heredoc redirection still don't work with pipe, but work with simple command