### PR TITLE
fix(print_env_variable): improve handling of special variable '$?'

### DIFF
--- a/src/builtins/echo_utils.c
+++ b/src/builtins/echo_utils.c
@@ -61,7 +61,7 @@ static char *remove_quotes(char *str)
 void print_env_variable(shell_t *shell, char *var)
 {
     char *value = NULL;
-    
+
     if (strcmp(var, "$?") == 0) {
         printf_flush("%d", shell->exit_code);
         return;

--- a/src/builtins/echo_utils.c
+++ b/src/builtins/echo_utils.c
@@ -60,8 +60,13 @@ static char *remove_quotes(char *str)
 
 void print_env_variable(shell_t *shell, char *var)
 {
-    char *value = get_env_value(shell, var + 1);
-
+    char *value = NULL;
+    
+    if (strcmp(var, "$?") == 0) {
+        printf_flush("%d", shell->exit_code);
+        return;
+    }
+    value = get_env_value(shell, var + 1);
     if (!value) {
         printf_flush("%s: Undefined variable.\n", var + 1);
         shell->exit_code = 1;


### PR DESCRIPTION
This pull request introduces a change to the `print_env_variable` function in `src/builtins/echo_utils.c` to handle the special case of the `$?` variable, which represents the shell's exit code. The most important change is the addition of logic to check for `$?` and print the exit code directly.

### Enhancements to environment variable handling:

* [`src/builtins/echo_utils.c`](diffhunk://#diff-f09757f101387294380ac1db3dd79e350295ca944da293f85f7adf6979ffca99L63-R69): Updated the `print_env_variable` function to handle the `$?` variable. If `$?` is detected, the function now prints the shell's exit code and skips the call to `get_env_value`. This ensures proper handling of this special variable.