### PR TITLE
fix: memory corruption due to buffer clearing

### DIFF
--- a/include/line_editing.h
+++ b/include/line_editing.h
@@ -12,7 +12,7 @@
     #include <stdbool.h>
     #include "shell.h"
 
-typedef void (*key_handler_t)(shell_t *shell, char *buffer, int *index);
+typedef void (*key_handler_t)(shell_t *shell, char **buffer, int *index);
 
 typedef struct escape_mapping_s {
     int code;
@@ -26,9 +26,9 @@ void restore_terminal_settings(void);
 
 void set_non_canonical_mode(void);
 
-bool handle_escape_sequence(shell_t *shell_info, char *buffer, int *index);
-void handle_history_up(shell_t *shell, char *buffer, int *index);
-void handle_history_down(shell_t *shell, char *buffer, int *index);
+bool handle_escape_sequence(shell_t *shell_info, char **buffer, int *index);
+void handle_history_up(shell_t *shell, char **buffer, int *index);
+void handle_history_down(shell_t *shell, char **buffer, int *index);
 char *read_command_line(shell_t *shell_info, bool *had_error);
 
 #endif /* !LINE_EDITING_H_ */

--- a/include/shell.h
+++ b/include/shell.h
@@ -1,6 +1,6 @@
 /*
 ** EPITECH PROJECT, 2025
-** 42sh [WSL: Ubuntu-24.04]
+** 42sh
 ** File description:
 ** shell
 */
@@ -36,6 +36,7 @@ struct shell_s {
     int local_size;
     int exit_code;
     int history_index;
+    int buffer_capacity;
     history_t *history;
 };
 

--- a/src/builtins/builtin_exit.c
+++ b/src/builtins/builtin_exit.c
@@ -8,6 +8,7 @@
 #include "shell.h"
 #include "env.h"
 #include "command.h"
+#include "line_editing.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -21,6 +22,7 @@ int builtin_exit(shell_t *shell, char **args)
     if (args[1]) {
         exit_code = atoi(args[1]);
     }
+    restore_terminal_settings();
     free_shell(shell);
     exit(exit_code);
 }

--- a/src/line_editing/handlers.c
+++ b/src/line_editing/handlers.c
@@ -8,11 +8,12 @@
 #include "shell.h"
 #include <unistd.h>
 #include <string.h>
+#include <stdlib.h>
 #include "line_editing.h"
 
-static void clear_buffer(char *buffer)
+static void clear_buffer(char *buffer, int capacity)
 {
-    for (int i = 0; buffer[i]; i++)
+    for (int i = 0; i < capacity; i++)
         buffer[i] = '\0';
 }
 
@@ -34,36 +35,67 @@ static void copy_command_to_buffer(
     *index = i;
 }
 
-void handle_history_up(shell_t *shell, char *buffer, int *index)
+static bool should_return(shell_t *shell, char **buffer, int *index)
 {
-    const char *command;
+    return (!shell || !shell->history || shell->history->count == 0
+        || !*buffer || !index);
+}
 
-    if (!shell || !shell->history || shell->history->count == 0
-        || !buffer || !index)
-        return;
+static void update_history_index(shell_t *shell)
+{
     if (shell->history_index == shell->history->count)
         shell->history_index = shell->history->count - 1;
     else if (shell->history_index > 0)
         shell->history_index--;
+}
+
+static bool reallocate_buffer(char **buffer, int *capacity, int len)
+{
+    char *new_buf = NULL;
+
+    if (len + 1 < *capacity)
+        return true;
+    new_buf = realloc(*buffer, len + 1);
+    if (!new_buf)
+        return false;
+    *buffer = new_buf;
+    *capacity = len + 1;
+    return true;
+}
+
+void handle_history_up(shell_t *shell, char **buffer, int *index)
+{
+    const char *command;
+    int len;
+
+    if (should_return(shell, buffer, index))
+        return;
+    update_history_index(shell);
     command = shell->history->entries[shell->history_index].command;
     if (!command)
         return;
     write_prompt();
-    clear_buffer(buffer);
-    copy_command_to_buffer(command, buffer, index);
+    clear_buffer(*buffer, shell->buffer_capacity);
+    len = strlen(command);
+    if (!reallocate_buffer(buffer, &shell->buffer_capacity, len))
+        return;
+    copy_command_to_buffer(command, *buffer, index);
 }
 
-void handle_history_down(shell_t *shell, char *buffer, int *index)
+void handle_history_down(shell_t *shell, char **buffer, int *index)
 {
     const char *last_command;
+    int len;
 
-    if (!shell || !shell->history || shell->history->count == 0
-        || !buffer || !index)
+    if (should_return(shell, buffer, index))
         return;
     last_command = shell->history->entries[shell->history->count - 1].command;
     if (!last_command)
         return;
     write_prompt();
-    clear_buffer(buffer);
-    copy_command_to_buffer(last_command, buffer, index);
+    clear_buffer(*buffer, shell->buffer_capacity);
+    len = strlen(last_command);
+    if (!reallocate_buffer(buffer, &shell->buffer_capacity, len))
+        return;
+    copy_command_to_buffer(last_command, *buffer, index);
 }

--- a/src/line_editing/terminal_control.c
+++ b/src/line_editing/terminal_control.c
@@ -32,7 +32,7 @@ void set_non_canonical_mode(void)
     tcsetattr(STDIN_FILENO, TCSANOW, &t);
 }
 
-bool handle_escape_sequence(shell_t *shell, char *buffer, int *index)
+bool handle_escape_sequence(shell_t *shell, char **buffer, int *index)
 {
     char seq[2];
 


### PR DESCRIPTION
This pull request introduces changes to improve the handling of dynamic buffer resizing and memory management in the shell's line editing functionality. The key updates include transitioning from a single `char *buffer` to a double pointer `char **buffer` for better flexibility, adding dynamic buffer reallocation logic, and introducing a `buffer_capacity` field in the `shell_t` structure to track buffer size. These changes enhance the robustness and scalability of the command-line interface.

### Buffer Management Improvements:

* Updated function signatures in `include/line_editing.h` to use `char **buffer` instead of `char *buffer`, enabling dynamic buffer management. [[1]](diffhunk://#diff-bc152e836a67453bf6b35a9fb2857b97ee6e84f2be2087903ff77b367de30c76L15-R15) [[2]](diffhunk://#diff-bc152e836a67453bf6b35a9fb2857b97ee6e84f2be2087903ff77b367de30c76L29-R31)
* Added `buffer_capacity` to the `shell_t` structure in `include/shell.h` to track the current buffer size.
* Implemented `reallocate_buffer` in `src/line_editing/handlers.c` to dynamically resize the buffer when needed, ensuring sufficient capacity for new commands.
* Modified `resize_buffer` in `src/line_editing/read_command_line.c` to be non-static and updated its usage to synchronize `buffer_capacity` with the shell state. [[1]](diffhunk://#diff-66d805d50af7ea0f311b5c8ebd7ca915db7004a30cf09197daa8958551cd51a3R21-R28) [[2]](diffhunk://#diff-66d805d50af7ea0f311b5c8ebd7ca915db7004a30cf09197daa8958551cd51a3R73-R76)

### Refactoring and Code Simplification:

* Refactored `handle_history_up` and `handle_history_down` in `src/line_editing/handlers.c` to use the new buffer management logic and ensure safe reallocation.
* Introduced helper functions `should_return` and `update_history_index` to simplify history navigation logic.
* Updated `handle_escape_sequence` across files to align with the new `char **buffer` convention.

### Miscellaneous:

* Adjusted the project header in `include/shell.h` to remove WSL-specific details.
* Fixed minor issues in `handle_input_character` in `src/line_editing/read_command_line.c` to align with the new buffer handling approach.…nctions to use double pointer for dynamic resizing