### PR TITLE
fix(shell): improve prompt handling and standardize hostname fallback

### DIFF
--- a/src/line_editing/handlers.c
+++ b/src/line_editing/handlers.c
@@ -74,7 +74,8 @@ void handle_history_up(shell_t *shell, char **buffer, int *index)
     command = shell->history->entries[shell->history_index].command;
     if (!command)
         return;
-    write_prompt();
+    write(STDOUT_FILENO, "\r\033[K", 4);
+    display_prompt(shell);
     clear_buffer(*buffer, shell->buffer_capacity);
     len = strlen(command);
     if (!reallocate_buffer(buffer, &shell->buffer_capacity, len))
@@ -92,7 +93,8 @@ void handle_history_down(shell_t *shell, char **buffer, int *index)
     last_command = shell->history->entries[shell->history->count - 1].command;
     if (!last_command)
         return;
-    write_prompt();
+    write(STDOUT_FILENO, "\r\033[K", 4);
+    display_prompt(shell);
     clear_buffer(*buffer, shell->buffer_capacity);
     len = strlen(last_command);
     if (!reallocate_buffer(buffer, &shell->buffer_capacity, len))

--- a/src/utils/gethostname.c
+++ b/src/utils/gethostname.c
@@ -22,14 +22,14 @@ char *my_gethostname(void)
     char *hostname = NULL;
 
     if (fd == -1)
-        return strdup("");
+        return strdup("42sh");
     if (bytes_read <= 0)
-        return strdup("");
+        return strdup("42sh");
     close(fd);
     buffer[bytes_read] = '\0';
     hostname = malloc(bytes_read);
     if (!hostname)
-        return strdup("");
+        return strdup("42sh");
     for (ssize_t i = 0; i < bytes_read; i++)
         hostname[i] = buffer[i];
     hostname[bytes_read - 1] = '\0';


### PR DESCRIPTION
This pull request includes updates to improve prompt handling in history navigation and standardize hostname behavior. The most important changes are grouped below by theme:

### Prompt handling improvements:
* Updated `handle_history_up` and `handle_history_down` in `src/line_editing/handlers.c` to replace `write_prompt()` with a combination of clearing the current line (`write(STDOUT_FILENO, "\r* Updated `handle_history_up` and `handle_history_down` in `src/line_editing/handlers.c` to replace `write_prompt()` with a combination of clearing the current line (`write(STDOUT_FILENO, "\r\033[K", 4)`) and calling `display_prompt()` for better visual consistency. ([src/line_editing/handlers.cL77-R78](diffhunk://#diff-da455a6482002d1d063464f9946d530c2c8c3ae0a0c37fc35ade5e94568fb4efL77-R78), [src/line_editing/handlers.cL95-R97](diffhunk://#diff-da455a6482002d1d063464f9946d530c2c8c3ae0a0c37fc35ade5e94568fb4efL95-R97))33[K", 4)`) and calling `display_prompt()` for better visual consistency. [[1]](diffhunk://#diff-da455a6482002d1d063464f9946d530c2c8c3ae0a0c37fc35ade5e94568fb4efL77-R78) [[2]](diffhunk://#diff-da455a6482002d1d063464f9946d530c2c8c3ae0a0c37fc35ade5e94568fb4efL95-R97)

### Hostname standardization:
* Modified `my_gethostname` in `src/utils/gethostname.c` to return `"42sh"` instead of an empty string (`""`) in cases where the hostname cannot be determined, ensuring consistent behavior.