### PR TITLE
refactor(handlers): remove unused write_prompt function

### DIFF
--- a/src/line_editing/handlers.c
+++ b/src/line_editing/handlers.c
@@ -17,11 +17,6 @@ static void clear_buffer(char *buffer, int capacity)
         buffer[i] = '\0';
 }
 
-static void write_prompt(void)
-{
-    write(STDOUT_FILENO, "\r\033[K$>", 6);
-}
-
 static void copy_command_to_buffer(
     const char *command, char *buffer, int *index)
 {


### PR DESCRIPTION
This pull request removes an unused function from the `handlers.c` file, simplifying the codebase.

Codebase simplification:

* [`src/line_editing/handlers.c`](diffhunk://#diff-da455a6482002d1d063464f9946d530c2c8c3ae0a0c37fc35ade5e94568fb4efL20-L24): Removed the unused `write_prompt` function, which was responsible for writing a prompt to the terminal. This function was no longer being called anywhere in the code.