### PR TITLE
fix(builtin_exit): ensure exit message is flushed before exiting

### DIFF
--- a/src/builtins/builtin_exit.c
+++ b/src/builtins/builtin_exit.c
@@ -23,6 +23,7 @@ int builtin_exit(shell_t *shell, char **args)
         exit_code = atoi(args[1]);
     }
     restore_terminal_settings();
+    printf_flush("exit\n");
     free_shell(shell);
     exit(exit_code);
 }


### PR DESCRIPTION
This pull request makes a small improvement to the `builtin_exit` function in `src/builtins/builtin_exit.c`. The change ensures a message is flushed to the output before the shell exits.

* [`src/builtins/builtin_exit.c`](diffhunk://#diff-ff107d06c79682fe84016cdd95c3fd372c7aa441d383dde7ab9c8ed5ec70e4bfR26): Added a call to `printf_flush("exit\n")` to ensure the "exit" message is printed and flushed to the output before freeing resources and exiting.